### PR TITLE
fix: set default locale to pt-BR for Calendar component

### DIFF
--- a/resources/js/components/ui/calendar.tsx
+++ b/resources/js/components/ui/calendar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
+import { ptBR } from "date-fns/locale"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
@@ -15,6 +16,7 @@ function Calendar({
     <DayPicker
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
+      locale={ptBR}
       classNames={{
         months: "flex flex-col sm:flex-row gap-2",
         month: "flex flex-col gap-4",

--- a/resources/js/pages/Reservas/fragments/ReservasFilters.tsx
+++ b/resources/js/pages/Reservas/fragments/ReservasFilters.tsx
@@ -64,7 +64,7 @@ export function ReservasFilters({
                         </Button>
                     </PopoverTrigger>
                     <PopoverContent className="w-auto p-0" align="start">
-                        <Calendar mode="single" selected={selectedDate} onSelect={onDateChange} locale={ptBR} initialFocus />
+                        <Calendar mode="single" selected={selectedDate} onSelect={onDateChange} initialFocus />
                     </PopoverContent>
                 </Popover>
             </div>


### PR DESCRIPTION
This pull request updates the locale handling for the `Calendar` component to ensure consistent localization throughout the application. The main change is moving the locale configuration for the calendar into the component itself, rather than requiring it to be passed in every usage.

**Localization improvements:**

* The `ptBR` locale import and configuration for the calendar have been moved directly into the `Calendar` component (`resources/js/components/ui/calendar.tsx`), so the calendar now always uses the Brazilian Portuguese locale by default. [[1]](diffhunk://#diff-6ebcb242324990dcfe1160c83488ca7cfdcf4e109a4ddb4c543ce87820784729R4) [[2]](diffhunk://#diff-6ebcb242324990dcfe1160c83488ca7cfdcf4e109a4ddb4c543ce87820784729R19)
* The redundant `locale={ptBR}` prop was removed from the `Calendar` usage in `ReservasFilters`, since the locale is now handled internally by the component. (`resources/js/pages/Reservas/fragments/ReservasFilters.tsx`)