### PR TITLE
fix(deploy): use single frontend build context to prevent asset hash mismatches

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Install & Build Frontend
         env:
           VITE_REVERB_APP_KEY: ${{ secrets.VITE_REVERB_APP_KEY }}
+          VITE_REVERB_HOST: ${{ secrets.VITE_REVERB_HOST }}
+          VITE_REVERB_PORT: ${{ secrets.VITE_REVERB_PORT }}
+          VITE_REVERB_SCHEME: ${{ secrets.VITE_REVERB_SCHEME }}
         run: npm ci && npm run build
 
       - name: Build and push PHP App Image
@@ -139,11 +142,6 @@ jobs:
           push: true
           tags: ${{ steps.meta-app.outputs.tags }}
           labels: ${{ steps.meta-app.outputs.labels }}
-          build-args: |
-            VITE_REVERB_APP_KEY=${{ secrets.VITE_REVERB_APP_KEY }}
-            VITE_REVERB_HOST=${{ secrets.VITE_REVERB_HOST }}
-            VITE_REVERB_PORT=${{ secrets.VITE_REVERB_PORT }}
-            VITE_REVERB_SCHEME=${{ secrets.VITE_REVERB_SCHEME }}
 
       - name: Build and push Web (Caddy) Image
         uses: docker/build-push-action@v5

--- a/docker/production/caddy/Dockerfile
+++ b/docker/production/caddy/Dockerfile
@@ -4,6 +4,4 @@ FROM caddy:alpine
 WORKDIR /var/www
 
 # Copy the built public assets from the CI/CD build stage
-# Note: In GitHub Actions, the 'public' folder is populated by 'npm run build' 
-# before this Docker image is built.
 COPY ./public /var/www/public

--- a/docker/production/php-fpm/Dockerfile
+++ b/docker/production/php-fpm/Dockerfile
@@ -1,35 +1,4 @@
-# Stage 1: Build frontend assets
-FROM node:20-alpine AS frontend-builder
-
-WORKDIR /var/www
-
-# Accept build arguments for environment variables
-ARG VITE_REVERB_APP_KEY
-ARG VITE_REVERB_HOST
-ARG VITE_REVERB_PORT
-ARG VITE_REVERB_SCHEME
-
-# Set environment variables for the build process
-ENV VITE_REVERB_APP_KEY=$VITE_REVERB_APP_KEY
-ENV VITE_REVERB_HOST=$VITE_REVERB_HOST
-ENV VITE_REVERB_PORT=$VITE_REVERB_PORT
-ENV VITE_REVERB_SCHEME=$VITE_REVERB_SCHEME
-
-# Copy only necessary files for npm install to leverage Docker layer caching
-COPY package.json package-lock.json ./
-RUN npm ci
-
-# Copy the rest of the frontend-related source code
-COPY vite.config.ts .
-COPY tsconfig.json .
-COPY tailwind.config.js .
-COPY eslint.config.js .
-COPY resources/ ./resources
-
-# Build the frontend assets
-RUN npm run build
-
-# Stage 2: Build environment and Composer dependencies
+# Stage 1: Build environment and Composer dependencies
 FROM php:8.4-fpm AS builder
 
 # Install system dependencies and PHP extensions required for Laravel + MySQL/PostgreSQL support
@@ -74,7 +43,7 @@ COPY . /var/www
 RUN composer dump-autoload --optimize
 
 
-# Stage 3: Production environment
+# Stage 2: Production environment
 FROM php:8.4-fpm as production
 
 # Install only runtime libraries needed in production
@@ -113,14 +82,8 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # Copy the application code and dependencies from the build stage
 COPY --from=builder /var/www /var/www
 
-# Copy compiled frontend assets
-COPY --from=frontend-builder /var/www/public/build /var/www/public/build
-
-# Set working directory
-WORKDIR /var/www
-
-# Copy the initial storage structure to the correct location
-RUN php artisan storage:link
+# Copy the pre-built frontend assets from the host context
+COPY ./public/build /var/www/public/build
 
 # Ensure correct permissions
 RUN chown -R www-data:www-data /var/www


### PR DESCRIPTION
Building the frontend twice (once on the host for Caddy, and once inside the Docker container for PHP-FPM) resulted in different file hashes due to environment variable differences. This caused the Caddy web server to return 404s (as text/html) for JS/CSS assets requested by the Laravel view. This fix ensures the frontend is built exactly once on the GitHub Actions host, and the output is used for both the PHP and Caddy Docker images.