### PR TITLE
fix(deploy): skip db wait in entrypoint for one-off commands

### DIFF
--- a/docker/production/php-fpm/entrypoint.sh
+++ b/docker/production/php-fpm/entrypoint.sh
@@ -1,35 +1,28 @@
 #!/bin/sh
 set -e
 
-# Function to check if the database is ready
-is_db_ready() {
-    php artisan db:monitor --quiet || false
-}
+# If the command is 'php-fpm', it means we're starting the main server.
+# In this case, wait for the database to be ready before proceeding.
+if [ "$1" = 'php-fpm' ]; then
+    echo "Waiting for database to be ready..."
+    # Use a loop to wait for the db:monitor command to succeed.
+    # The command will fail with a non-zero exit code if it can't connect.
+    while ! php artisan db:monitor --quiet; do
+      sleep 2
+    done
+    echo "Database is ready."
 
-# Wait for the database
-echo "Waiting for database to be ready..."
-while ! is_db_ready; do
-  sleep 2
-done
-echo "Database is ready."
-
-# Initialize storage directory if empty
-# ----------------------------------------------------------
-# If the storage directory is empty, copy the initial contents
-# and set the correct permissions.
-# ----------------------------------------------------------
-if [ ! "$(ls -A /var/www/storage)" ]; then
-  echo "Initializing storage directory from storage-init..."
-  cp -R /var/www/storage-init/. /var/www/storage || { echo "Error: Failed to copy storage-init."; exit 1; }
-  echo "Setting permissions for /var/www/storage..."
-  chown -R www-data:www-data /var/www/storage || { echo "Error: Failed to chown /var/www/storage."; exit 1; }
-  echo "Storage directory initialized and permissions set."
+    # Initialize storage directory if empty
+    if [ ! "$(ls -A /var/www/storage/app)" ]; then
+      echo "Initializing storage directory from storage-init..."
+      cp -R /var/www/storage-init/. /var/www/storage
+      chown -R www-data:www-data /var/www/storage
+      echo "Storage directory initialized."
+    fi
 fi
 
-# Remove storage-init directory (cleanup)
-echo "Removing /var/www/storage-init directory..."
-rm -rf /var/www/storage-init || { echo "Warning: Failed to remove storage-init directory."; }
+# Cleanup the init directory regardless, as it's not needed after startup
+rm -rf /var/www/storage-init
 
-# Run the default command (php-fpm)
-echo "Starting PHP-FPM..."
+# Execute the command passed to the container (e.g., "php-fpm" or "php artisan migrate")
 exec "$@"


### PR DESCRIPTION
Avoids 'Could not open input file: artisan' errors during pre-flight migrations.