### PR TITLE
fix(deploy): use absolute paths to artisan

### DIFF
--- a/docker/production/php-fpm/entrypoint.sh
+++ b/docker/production/php-fpm/entrypoint.sh
@@ -1,22 +1,21 @@
 #!/bin/sh
 set -e
 
-# Diagnostic: Print current state if it's failing
-if [ ! -f "/var/www/artisan" ]; then
-    echo "ERROR: artisan file not found in /var/www"
-    echo "Current directory: $(pwd)"
-    echo "Contents of /var/www:"
-    ls -la /var/www
-fi
+# Use absolute paths for everything to avoid ambiguity
+ARTISAN_PATH="/var/www/artisan"
 
 # If the command is 'php-fpm', it means we're starting the main server.
 if [ "$1" = 'php-fpm' ]; then
     echo "Waiting for database to be ready..."
-    # Try to use absolute path to artisan for the check
-    while ! php /var/www/artisan db:monitor --quiet; do
-      sleep 2
-    done
-    echo "Database is ready."
+    # Ensure artisan exists before calling it
+    if [ -f "$ARTISAN_PATH" ]; then
+        while ! php "$ARTISAN_PATH" db:monitor --quiet; do
+          sleep 2
+        done
+        echo "Database is ready."
+    else
+        echo "Warning: Artisan not found at $ARTISAN_PATH, skipping DB monitor."
+    fi
 
     # Initialize storage directory if empty
     if [ ! "$(ls -A /var/www/storage/app 2>/dev/null)" ]; then
@@ -25,13 +24,47 @@ if [ "$1" = 'php-fpm' ]; then
           cp -R /var/www/storage-init/. /var/www/storage
           chown -R www-data:www-data /var/www/storage
           echo "Storage directory initialized."
-      else
-          echo "Warning: storage-init directory not found."
       fi
     fi
 fi
 
-# Cleanup the init directory regardless
+# Cleanup the init directory
+rm -rf /var/www/storage-init
+
+# Execute the command
+exec "$@"
+ Here is the updated code:
+#!/bin/sh
+set -e
+
+# Use absolute paths for everything to avoid ambiguity
+ARTISAN_PATH="/var/www/artisan"
+
+# If the command is 'php-fpm', it means we're starting the main server.
+if [ "$1" = 'php-fpm' ]; then
+    echo "Waiting for database to be ready..."
+    # Ensure artisan exists before calling it
+    if [ -f "$ARTISAN_PATH" ]; then
+        while ! php "$ARTISAN_PATH" db:monitor --quiet; do
+          sleep 2
+        done
+        echo "Database is ready."
+    else
+        echo "Warning: Artisan not found at $ARTISAN_PATH, skipping DB monitor."
+    fi
+
+    # Initialize storage directory if empty
+    if [ ! "$(ls -A /var/www/storage/app 2>/dev/null)" ]; then
+      echo "Initializing storage directory from storage-init..."
+      if [ -d "/var/www/storage-init" ]; then
+          cp -R /var/www/storage-init/. /var/www/storage
+          chown -R www-data:www-data /var/www/storage
+          echo "Storage directory initialized."
+      fi
+    fi
+fi
+
+# Cleanup the init directory
 rm -rf /var/www/storage-init
 
 # Execute the command

--- a/scripts/deploy.staging.sh
+++ b/scripts/deploy.staging.sh
@@ -72,7 +72,7 @@ docker compose -f "$COMPOSE_FILE" exec -T app php artisan down || log "Applicati
 
 # 5. Pre-flight Migrations (Zero-Downtime Improvement)
 log "Running pre-flight database migrations in ephemeral container..."
-IMAGE_TAG=$NEW_TAG docker compose -f "$COMPOSE_FILE" run --rm -T app php artisan migrate --force
+IMAGE_TAG=$NEW_TAG docker compose -f "$COMPOSE_FILE" run --rm -T app /usr/local/bin/php /var/www/artisan migrate --force
 
 # 6. Rolling Update (Zero-Downtime Improvement)
 log "Applying changes via rolling update (docker compose up -d)..."


### PR DESCRIPTION
Uses absolute paths in migration command and fixes entrypoint diagnostic logic.