### PR TITLE
fix(test): robust user name assertion in notification tests

### DIFF
--- a/tests/Feature/NotificationsTest.php
+++ b/tests/Feature/NotificationsTest.php
@@ -95,7 +95,7 @@ class NotificationsTest extends TestCase
         $this->assertStringContainsString($this->reserva->titulo, $mailData);
         $this->assertStringContainsString('Deferida', $mailData);
         $this->assertStringContainsString('Solicitante:', $mailData);
-        $this->assertStringContainsString($this->user->name, $mailData);
+        $this->assertStringContainsString(e($this->user->name), $mailData);
         $this->assertStringContainsString('Avaliador:', $mailData);
         $this->assertStringContainsString($this->manager->name, $mailData);
         $this->assertStringContainsString(route('reservas.show', $this->reserva->id), $mailData);
@@ -143,7 +143,7 @@ class NotificationsTest extends TestCase
         $mailData = (string) $mailMessage->render();
         $this->assertStringContainsString('Houve um erro ao processar sua solicitação', $mailData);
         $this->assertStringContainsString($this->reserva->titulo, $mailData);
-        $this->assertStringContainsString($this->user->name, $mailData);
+        $this->assertStringContainsString(e($this->user->name), $mailData);
         $this->assertStringContainsString(route('reservas.index'), $mailData);
 
         // Test Broadcast
@@ -166,7 +166,7 @@ class NotificationsTest extends TestCase
         $mailData = (string) $mailMessage->render();
         $this->assertStringContainsString('Uma reserva foi cancelada pelo solicitante:', $mailData);
         $this->assertStringContainsString($this->reserva->titulo, $mailData);
-        $this->assertStringContainsString($this->user->name, $mailData);
+        $this->assertStringContainsString(e($this->user->name), $mailData);
         $this->assertStringContainsString(route('gestor.reservas.index'), $mailData);
 
         // Test Broadcast
@@ -211,7 +211,7 @@ class NotificationsTest extends TestCase
         $mailData = (string) $mailMessage->render();
         $this->assertStringContainsString('Houve um erro ao processar sua solicitação', $mailData); // uses reservation_failed view
         $this->assertStringContainsString($this->reserva->titulo, $mailData);
-        $this->assertStringContainsString($this->user->name, $mailData);
+        $this->assertStringContainsString(e($this->user->name), $mailData);
         $this->assertStringContainsString(route('reservas.edit', $this->reserva->id), $mailData);
 
         // Test Broadcast
@@ -298,7 +298,7 @@ class NotificationsTest extends TestCase
         $mailData = (string) $mailMessage->render();
         $this->assertStringContainsString('foi atualizado em nosso sistema.', $mailData);
         $this->assertStringContainsString($this->setor->nome, $mailData);
-        $this->assertStringContainsString($this->user->name, $mailData);
+        $this->assertStringContainsString(e($this->user->name), $mailData);
         $this->assertStringContainsString(route('institucional.setors.show', $this->setor->id), $mailData);
 
         // Test Broadcast


### PR DESCRIPTION
Fixes test failures caused by HTML encoding of user names with apostrophes.