### PR TITLE
fix(deploy): sync build assets into docker images using buildx context

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -106,6 +106,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.PAT }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract Docker metadata for App
         id: meta-app
         uses: docker/metadata-action@v5
@@ -132,6 +135,12 @@ jobs:
           VITE_REVERB_PORT: ${{ secrets.VITE_REVERB_PORT }}
           VITE_REVERB_SCHEME: ${{ secrets.VITE_REVERB_SCHEME }}
         run: npm ci && npm run build
+
+      - name: Verify Build Assets
+        run: |
+          ls -la public/
+          ls -la public/build/
+          ls -la public/build/manifest.json
 
       - name: Build and push PHP App Image
         uses: docker/build-push-action@v5

--- a/docker/production/caddy/Dockerfile
+++ b/docker/production/caddy/Dockerfile
@@ -4,4 +4,5 @@ FROM caddy:alpine
 WORKDIR /var/www
 
 # Copy the built public assets from the CI/CD build stage
-COPY ./public /var/www/public
+# We copy the entire public directory to ensure index.php and build/ are present
+COPY public /var/www/public

--- a/docker/production/php-fpm/Dockerfile
+++ b/docker/production/php-fpm/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: Build environment and Composer dependencies
 FROM php:8.4-fpm AS builder
 
-# Install system dependencies and PHP extensions required for Laravel + MySQL/PostgreSQL support
+# Install system dependencies and PHP extensions required for Laravel
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     unzip \
@@ -26,10 +26,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && docker-php-ext-enable redis \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Set the working directory inside the container
 WORKDIR /var/www
 
-# Copy composer.json and composer.lock first to leverage Docker layer caching
+# Copy composer.json and composer.lock first
 COPY composer.json composer.lock ./
 
 # Install Composer and dependencies
@@ -39,14 +38,14 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 # Copy the rest of the application code
 COPY . /var/www
 
-# Generate autoloader and run scripts now that application code is present
+# Generate autoloader
 RUN composer dump-autoload --optimize
 
 
 # Stage 2: Production environment
 FROM php:8.4-fpm as production
 
-# Install only runtime libraries needed in production
+# Install only runtime libraries needed
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     libicu-dev \
@@ -55,45 +54,44 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     procps \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Overwrite the problematic default config with correct settings
-# This ensures PHP-FPM runs in the foreground and listens on the correct port
+# Overwrite default config
 RUN printf "[global]\ndaemonize = no\n\n[www]\nlisten = 9000\n" > /usr/local/etc/php-fpm.d/zz-docker.conf
 
-# Download and install php-fpm health check script
+# Install health check script
 RUN curl -o /usr/local/bin/php-fpm-healthcheck \
     https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/master/php-fpm-healthcheck \
     && chmod +x /usr/local/bin/php-fpm-healthcheck
 
-# Copy the initialization script
+# Entrypoint
 COPY ./docker/production/php-fpm/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-# Copy the initial storage structure
+# Initial storage structure
 COPY ./storage /var/www/storage-init
 
-# Copy PHP extensions and libraries from the builder stage
+# Copy PHP extensions from builder
 COPY --from=builder /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
 COPY --from=builder /usr/local/bin/docker-php-ext-* /usr/local/bin/
 
-# Use the recommended production PHP configuration
+# Use production PHP configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Copy the application code and dependencies from the build stage
+# Copy the application code from builder
 COPY --from=builder /var/www /var/www
 
-# Copy the pre-built frontend assets from the host context
-COPY ./public/build /var/www/public/build
+# IMPORTANT: Copy the public directory EXPLICITLY from the context
+# This ensures that even if it was ignored in the builder stage, it's included here.
+COPY public /var/www/public
 
 # Ensure correct permissions
 RUN chown -R www-data:www-data /var/www
 
-# Switch to the non-privileged user to run the application
 USER www-data
 
-# Change the default command to run the entrypoint script
+WORKDIR /var/www
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-# Expose port 9000 and start php-fpm server
 EXPOSE 9000
 CMD ["php-fpm"]


### PR DESCRIPTION
Ensures assets generated by npm run build are included in both PHP and Caddy images by using Docker Buildx and explicit COPY of the public directory.