### PR TITLE
fix(deploy): use php image as source for caddy assets

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -160,6 +160,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-web.outputs.tags }}
           labels: ${{ steps.meta-web.outputs.labels }}
+          build-args: |
+            APP_IMAGE=ghcr.io/${{ github.repository }}/app:${{ steps.meta-app.outputs.version }}
 
       - name: Install cloudflared
         run: |

--- a/docker/production/caddy/Dockerfile
+++ b/docker/production/caddy/Dockerfile
@@ -1,8 +1,11 @@
+ARG APP_IMAGE=ghcr.io/uniespacos/app/app:latest
+FROM ${APP_IMAGE} AS app-source
+
 FROM caddy:alpine
 
 # Set the working directory
 WORKDIR /var/www
 
-# Copy the built public assets from the CI/CD build stage
-# We copy the entire public directory to ensure index.php and build/ are present
-COPY public /var/www/public
+# Copy the built public assets from the EXACTLY built app image
+# This ensures 100% consistency between PHP and Caddy containers
+COPY --from=app-source /var/www/public /var/www/public


### PR DESCRIPTION
Guarantees that Caddy always has the exact same assets as the PHP container by copying them directly from the app image during build.