### PR TITLE
fix(deploy): add opcache clear to deployment script

### DIFF
--- a/scripts/deploy.staging.sh
+++ b/scripts/deploy.staging.sh
@@ -103,6 +103,10 @@ log "Ensuring correct permissions..."
 docker compose -f "$COMPOSE_FILE" exec -T -u root app chown -R www-data:www-data /var/www/storage /var/www/bootstrap/cache
 docker compose -f "$COMPOSE_FILE" exec -T -u root app chmod -R 775 /var/www/storage /var/www/bootstrap/cache
 
+log "Clearing all caches and restarting opcache..."
+docker compose -f "$COMPOSE_FILE" exec -T -u www-data app php /var/www/artisan optimize:clear
+docker compose -f "$COMPOSE_FILE" exec -T -u www-data app php /var/www/artisan opcache:clear
+
 log "Refreshing application cache..."
 docker compose -f "$COMPOSE_FILE" exec -T -u www-data app php /var/www/artisan config:cache
 docker compose -f "$COMPOSE_FILE" exec -T -u www-data app php /var/www/artisan route:cache


### PR DESCRIPTION
Adds 'php artisan opcache:clear' to the deployment script to ensure the latest configuration is always used, which should resolve the 'Invalid Signature' error.