### PR TITLE
fix(deploy): correctly pass https proto from caddy to php-fpm

### DIFF
--- a/docker/staging/caddy/Caddyfile
+++ b/docker/staging/caddy/Caddyfile
@@ -15,10 +15,9 @@
 
     # Proxy to PHP-FPM
     php_fastcgi app:9000 {
-        # Ensure we pass the correct protocol to Laravel
-        # This is critical for URL signature verification
-        env HTTPS on
-        env HTTP_X_FORWARDED_PROTO https
+        # Dynamically set HTTPS=on for PHP if the X-Forwarded-Proto header is 'https'
+        # This is the definitive fix for Laravel's URL signature validation behind a proxy.
+        env HTTPS {header.X-Forwarded-Proto} == 'https' ? 'on' : 'off'
     }
 
     # Reverb WebSockets


### PR DESCRIPTION
This resolves the 'Invalid Signature' error by dynamically setting the HTTPS environment variable for PHP-FPM based on the incoming X-Forwarded-Proto header from Cloudflare. Also removes the unnecessary opcache:clear command.