### PR TITLE
feat: general reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ gha-creds-*.json
 
 .gemini/
 
+# Claude
+.claude
+CLAUDE.md
+/docs/claude/
+/.playwright-mcp/
+
 # Mailpit
 docker/development/mailpit/*
 

--- a/app/Enums/Relatorio/FormatoRelatorioEnum.php
+++ b/app/Enums/Relatorio/FormatoRelatorioEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Relatorio;
+
+enum FormatoRelatorioEnum: string
+{
+    case PDF = 'pdf';
+    case CSV = 'csv';
+    case XLSX = 'xlsx';
+
+    public function mimeType(): string
+    {
+        return match ($this) {
+            self::PDF => 'application/pdf',
+            self::CSV => 'text/csv; charset=UTF-8',
+            self::XLSX => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        };
+    }
+}

--- a/app/Enums/Relatorio/TipoRelatorioEnum.php
+++ b/app/Enums/Relatorio/TipoRelatorioEnum.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Relatorio;
+
+use App\Models\User;
+
+enum TipoRelatorioEnum: string
+{
+    case RESERVAS_PERIODO = 'reservas_periodo';
+    case OCUPACAO_ESPACOS = 'ocupacao_espacos';
+    case INVENTARIO_ESPACOS = 'inventario_espacos';
+    case INDICADORES_CONSOLIDADOS = 'indicadores_consolidados';
+
+    public function titulo(): string
+    {
+        return match ($this) {
+            self::RESERVAS_PERIODO => 'Relatório de Reservas por Período',
+            self::OCUPACAO_ESPACOS => 'Relatório de Ocupação de Espaços',
+            self::INVENTARIO_ESPACOS => 'Inventário de Espaços',
+            self::INDICADORES_CONSOLIDADOS => 'Indicadores Consolidados',
+        };
+    }
+
+    public function permissao(): string
+    {
+        return match ($this) {
+            self::RESERVAS_PERIODO => 'relatorios.reservas-periodo',
+            self::OCUPACAO_ESPACOS => 'relatorios.ocupacao-espacos',
+            self::INVENTARIO_ESPACOS => 'relatorios.inventario-espacos',
+            self::INDICADORES_CONSOLIDADOS => 'relatorios.indicadores-consolidados',
+        };
+    }
+
+    /**
+     * @return array<int, self>
+     */
+    public static function disponiveisPara(User $user): array
+    {
+        return array_values(array_filter(
+            self::cases(),
+            fn (self $tipo): bool => $user->hasPermissionTo($tipo->permissao())
+        ));
+    }
+}

--- a/app/Enums/Relatorio/TipoRelatorioEnum.php
+++ b/app/Enums/Relatorio/TipoRelatorioEnum.php
@@ -23,6 +23,20 @@ enum TipoRelatorioEnum: string
         };
     }
 
+    /**
+     * Titulo sem o prefixo "Relatorio de", para uso dentro da tela de
+     * relatorios, onde o contexto ja esta dado pelas abas.
+     */
+    public function tituloCurto(): string
+    {
+        return match ($this) {
+            self::RESERVAS_PERIODO => 'Reservas por Período',
+            self::OCUPACAO_ESPACOS => 'Ocupação de Espaços',
+            self::INVENTARIO_ESPACOS => 'Inventário de Espaços',
+            self::INDICADORES_CONSOLIDADOS => 'Indicadores Consolidados',
+        };
+    }
+
     public function permissao(): string
     {
         return match ($this) {

--- a/app/Enums/SituacaoReserva/SituacaoReservaEnum.php
+++ b/app/Enums/SituacaoReserva/SituacaoReservaEnum.php
@@ -11,4 +11,28 @@ enum SituacaoReservaEnum: string
     case PARCIALMENTE_DEFERIDA = 'parcialmente_deferida';
     case DEFERIDA = 'deferida';
     case INATIVA = 'inativa';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::EM_ANALISE => 'Em Análise',
+            self::INDEFERIDA => 'Indeferida',
+            self::PARCIALMENTE_DEFERIDA => 'Parcialmente Deferida',
+            self::DEFERIDA => 'Deferida',
+            self::INATIVA => 'Inativa',
+        };
+    }
+
+    /**
+     * Converte um valor cru do banco no rotulo legivel, sem quebrar
+     * caso apareca uma situacao desconhecida.
+     */
+    public static function labelDe(?string $valor): string
+    {
+        if ($valor === null) {
+            return '—';
+        }
+
+        return self::tryFrom($valor)?->label() ?? $valor;
+    }
 }

--- a/app/Http/Controllers/Gestor/GestorRelatorioController.php
+++ b/app/Http/Controllers/Gestor/GestorRelatorioController.php
@@ -7,9 +7,11 @@ namespace App\Http\Controllers\Gestor;
 use App\Enums\Relatorio\FormatoRelatorioEnum;
 use App\Enums\Relatorio\TipoRelatorioEnum;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Relatorio\DadosRelatorioRequest;
 use App\Http\Requests\Relatorio\GerarRelatorioRequest;
 use App\Services\Relatorio\Data\FiltrosRelatorio;
 use App\Services\Relatorio\RelatorioService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -27,11 +29,12 @@ final class GestorRelatorioController extends Controller
         $tipos = TipoRelatorioEnum::disponiveisPara(Auth::user());
         $tiposDisponiveis = array_map(fn (TipoRelatorioEnum $tipo) => [
             'value' => $tipo->value,
-            'label' => $tipo->titulo(),
+            'label' => $tipo->tituloCurto(),
         ], $tipos);
 
         return Inertia::render('Gestor/Relatorios/RelatoriosGestorPage', [
             'tipos_disponiveis' => $tiposDisponiveis,
+            'opcoes_inventario' => $this->service->opcoesInventario(Auth::user()),
         ]);
     }
 
@@ -43,5 +46,16 @@ final class GestorRelatorioController extends Controller
             FormatoRelatorioEnum::from($request->string('formato')->toString()),
             FiltrosRelatorio::fromArray($request->validated()),
         );
+    }
+
+    public function dados(DadosRelatorioRequest $request): JsonResponse
+    {
+        $dados = $this->service->agregar(
+            Auth::user(),
+            TipoRelatorioEnum::from($request->string('tipo')->toString()),
+            FiltrosRelatorio::fromArray($request->validated()),
+        );
+
+        return response()->json($dados);
     }
 }

--- a/app/Http/Controllers/Gestor/GestorRelatorioController.php
+++ b/app/Http/Controllers/Gestor/GestorRelatorioController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Gestor;
+
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Relatorio\GerarRelatorioRequest;
+use App\Services\Relatorio\Data\FiltrosRelatorio;
+use App\Services\Relatorio\RelatorioService;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class GestorRelatorioController extends Controller
+{
+    public function __construct(
+        private RelatorioService $service,
+    ) {}
+
+    public function index(): Response
+    {
+        $tipos = TipoRelatorioEnum::disponiveisPara(Auth::user());
+        $tiposDisponiveis = array_map(fn (TipoRelatorioEnum $tipo) => [
+            'value' => $tipo->value,
+            'label' => $tipo->titulo(),
+        ], $tipos);
+
+        return Inertia::render('Gestor/Relatorios/RelatoriosGestorPage', [
+            'tipos_disponiveis' => $tiposDisponiveis,
+        ]);
+    }
+
+    public function gerar(GerarRelatorioRequest $request): BinaryFileResponse|StreamedResponse
+    {
+        return $this->service->gerar(
+            Auth::user(),
+            TipoRelatorioEnum::from($request->string('tipo')->toString()),
+            FormatoRelatorioEnum::from($request->string('formato')->toString()),
+            FiltrosRelatorio::fromArray($request->validated()),
+        );
+    }
+}

--- a/app/Http/Controllers/Institucional/InstitucionalRelatorioController.php
+++ b/app/Http/Controllers/Institucional/InstitucionalRelatorioController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Institucional;
+
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Relatorio\GerarRelatorioRequest;
+use App\Services\Relatorio\Data\FiltrosRelatorio;
+use App\Services\Relatorio\RelatorioService;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class InstitucionalRelatorioController extends Controller
+{
+    public function __construct(
+        private RelatorioService $service,
+    ) {}
+
+    public function index(): Response
+    {
+        $tipos = TipoRelatorioEnum::disponiveisPara(Auth::user());
+        $tiposDisponiveis = array_map(fn (TipoRelatorioEnum $tipo) => [
+            'value' => $tipo->value,
+            'label' => $tipo->titulo(),
+        ], $tipos);
+
+        return Inertia::render('Administrativo/Relatorios/RelatoriosInstitucionalPage', [
+            'tipos_disponiveis' => $tiposDisponiveis,
+        ]);
+    }
+
+    public function gerar(GerarRelatorioRequest $request): BinaryFileResponse|StreamedResponse
+    {
+        return $this->service->gerar(
+            Auth::user(),
+            TipoRelatorioEnum::from($request->string('tipo')->toString()),
+            FormatoRelatorioEnum::from($request->string('formato')->toString()),
+            FiltrosRelatorio::fromArray($request->validated()),
+        );
+    }
+}

--- a/app/Http/Controllers/Institucional/InstitucionalRelatorioController.php
+++ b/app/Http/Controllers/Institucional/InstitucionalRelatorioController.php
@@ -7,9 +7,11 @@ namespace App\Http\Controllers\Institucional;
 use App\Enums\Relatorio\FormatoRelatorioEnum;
 use App\Enums\Relatorio\TipoRelatorioEnum;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Relatorio\DadosRelatorioRequest;
 use App\Http\Requests\Relatorio\GerarRelatorioRequest;
 use App\Services\Relatorio\Data\FiltrosRelatorio;
 use App\Services\Relatorio\RelatorioService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -27,11 +29,12 @@ final class InstitucionalRelatorioController extends Controller
         $tipos = TipoRelatorioEnum::disponiveisPara(Auth::user());
         $tiposDisponiveis = array_map(fn (TipoRelatorioEnum $tipo) => [
             'value' => $tipo->value,
-            'label' => $tipo->titulo(),
+            'label' => $tipo->tituloCurto(),
         ], $tipos);
 
         return Inertia::render('Administrativo/Relatorios/RelatoriosInstitucionalPage', [
             'tipos_disponiveis' => $tiposDisponiveis,
+            'opcoes_inventario' => $this->service->opcoesInventario(Auth::user()),
         ]);
     }
 
@@ -43,5 +46,16 @@ final class InstitucionalRelatorioController extends Controller
             FormatoRelatorioEnum::from($request->string('formato')->toString()),
             FiltrosRelatorio::fromArray($request->validated()),
         );
+    }
+
+    public function dados(DadosRelatorioRequest $request): JsonResponse
+    {
+        $dados = $this->service->agregar(
+            Auth::user(),
+            TipoRelatorioEnum::from($request->string('tipo')->toString()),
+            FiltrosRelatorio::fromArray($request->validated()),
+        );
+
+        return response()->json($dados);
     }
 }

--- a/app/Http/Requests/Relatorio/DadosRelatorioRequest.php
+++ b/app/Http/Requests/Relatorio/DadosRelatorioRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Relatorio;
+
+use App\Enums\Agenda\AgendaEnum;
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Enums\SituacaoReserva\SituacaoReservaEnum;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+final class DadosRelatorioRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $tipo = TipoRelatorioEnum::tryFrom($this->string('tipo')->toString());
+
+        if ($tipo === null) {
+            return false;
+        }
+
+        return (bool) $this->user()?->hasPermissionTo($tipo->permissao());
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tipo' => ['required', new Enum(TipoRelatorioEnum::class)],
+            'data_inicio' => ['nullable', 'date'],
+            'data_fim' => ['nullable', 'date', 'after_or_equal:data_inicio'],
+            'situacoes' => ['nullable', 'array'],
+            'situacoes.*' => ['in:'.implode(',', array_column(SituacaoReservaEnum::cases(), 'value'))],
+            'turnos' => ['nullable', 'array'],
+            'turnos.*' => ['in:'.implode(',', array_column(AgendaEnum::cases(), 'value'))],
+            'unidade_id' => ['nullable', 'integer', 'exists:unidades,id'],
+            'modulo_id' => ['nullable', 'integer', 'exists:modulos,id'],
+            'andar_id' => ['nullable', 'integer', 'exists:andars,id'],
+            'espaco_id' => ['nullable', 'integer', 'exists:espacos,id'],
+            'setor_id' => ['nullable', 'integer', 'exists:setors,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Relatorio/GerarRelatorioRequest.php
+++ b/app/Http/Requests/Relatorio/GerarRelatorioRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Relatorio;
+
+use App\Enums\Agenda\AgendaEnum;
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Enums\SituacaoReserva\SituacaoReservaEnum;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+final class GerarRelatorioRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $tipo = TipoRelatorioEnum::tryFrom($this->string('tipo')->toString());
+
+        if ($tipo === null) {
+            return false;
+        }
+
+        return (bool) $this->user()?->hasPermissionTo($tipo->permissao());
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tipo' => ['required', new Enum(TipoRelatorioEnum::class)],
+            'formato' => ['required', new Enum(FormatoRelatorioEnum::class)],
+            'data_inicio' => ['nullable', 'date'],
+            'data_fim' => ['nullable', 'date', 'after_or_equal:data_inicio'],
+            'situacoes' => ['nullable', 'array'],
+            'situacoes.*' => ['in:'.implode(',', array_column(SituacaoReservaEnum::cases(), 'value'))],
+            'turnos' => ['nullable', 'array'],
+            'turnos.*' => ['in:'.implode(',', array_column(AgendaEnum::cases(), 'value'))],
+            'unidade_id' => ['nullable', 'integer', 'exists:unidades,id'],
+            'modulo_id' => ['nullable', 'integer', 'exists:modulos,id'],
+            'andar_id' => ['nullable', 'integer', 'exists:andars,id'],
+            'espaco_id' => ['nullable', 'integer', 'exists:espacos,id'],
+            'setor_id' => ['nullable', 'integer', 'exists:setors,id'],
+        ];
+    }
+}

--- a/app/Providers/RelatorioServiceProvider.php
+++ b/app/Providers/RelatorioServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Services\Relatorio\Exporters\CsvExporter;
+use App\Services\Relatorio\Exporters\ExporterFactory;
+use App\Services\Relatorio\Exporters\PdfExporter;
+use App\Services\Relatorio\Exporters\XlsxExporter;
+use Illuminate\Support\ServiceProvider;
+
+final class RelatorioServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../config/relatorios.php', 'relatorios');
+
+        $this->app->tag([PdfExporter::class, CsvExporter::class, XlsxExporter::class], 'relatorio.exporters');
+
+        $this->app->singleton(ExporterFactory::class, fn ($app) => new ExporterFactory($app->tagged('relatorio.exporters')));
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void {}
+}

--- a/app/Services/Relatorio/Data/ColunaRelatorio.php
+++ b/app/Services/Relatorio/Data/ColunaRelatorio.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Data;
+
+final readonly class ColunaRelatorio
+{
+    public function __construct(
+        public string $chave,
+        public string $rotulo,
+        public string $tipo = 'string',
+        public int $largura = 20,
+    ) {}
+}

--- a/app/Services/Relatorio/Data/DadosRelatorio.php
+++ b/app/Services/Relatorio/Data/DadosRelatorio.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Data;
+
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use Carbon\CarbonImmutable;
+
+final readonly class DadosRelatorio
+{
+    public function __construct(
+        public TipoRelatorioEnum $tipo,
+        public string $titulo,
+        public string $subtitulo,
+        public array $colunas,
+        public array $linhas,
+        public array $sumario,
+        public array $filtrosAplicados,
+        public string $geradoPor,
+        public CarbonImmutable $geradoEm,
+    ) {}
+
+    public function totalLinhas(): int
+    {
+        return count($this->linhas);
+    }
+}

--- a/app/Services/Relatorio/Data/FiltrosRelatorio.php
+++ b/app/Services/Relatorio/Data/FiltrosRelatorio.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Data;
+
+use Carbon\CarbonImmutable;
+
+final readonly class FiltrosRelatorio
+{
+    public function __construct(
+        public ?CarbonImmutable $dataInicio = null,
+        public ?CarbonImmutable $dataFim = null,
+        public ?array $situacoes = null,
+        public ?array $turnos = null,
+        public ?int $instituicaoId = null,
+        public ?int $unidadeId = null,
+        public ?int $moduloId = null,
+        public ?int $andarId = null,
+        public ?int $espacoId = null,
+        public ?int $setorId = null,
+        public ?array $agendaIds = null,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            dataInicio: isset($data['data_inicio']) ? CarbonImmutable::parse($data['data_inicio']) : null,
+            dataFim: isset($data['data_fim']) ? CarbonImmutable::parse($data['data_fim']) : null,
+            situacoes: $data['situacoes'] ?? null,
+            turnos: $data['turnos'] ?? null,
+            instituicaoId: isset($data['instituicao_id']) ? (int) $data['instituicao_id'] : null,
+            unidadeId: isset($data['unidade_id']) ? (int) $data['unidade_id'] : null,
+            moduloId: isset($data['modulo_id']) ? (int) $data['modulo_id'] : null,
+            andarId: isset($data['andar_id']) ? (int) $data['andar_id'] : null,
+            espacoId: isset($data['espaco_id']) ? (int) $data['espaco_id'] : null,
+            setorId: isset($data['setor_id']) ? (int) $data['setor_id'] : null,
+            agendaIds: $data['agenda_ids'] ?? null,
+        );
+    }
+
+    public function resumo(): array
+    {
+        $resumo = [];
+
+        if ($this->dataInicio !== null && $this->dataFim !== null) {
+            $inicio = $this->dataInicio->format('d/m/Y');
+            $fim = $this->dataFim->format('d/m/Y');
+            $resumo['Período'] = "{$inicio} a {$fim}";
+        } elseif ($this->dataInicio !== null) {
+            $resumo['Período'] = "{$this->dataInicio->format('d/m/Y')} a —";
+        } elseif ($this->dataFim !== null) {
+            $resumo['Período'] = "— a {$this->dataFim->format('d/m/Y')}";
+        }
+
+        if ($this->situacoes !== null && ! empty($this->situacoes)) {
+            $resumo['Situações'] = implode(', ', $this->situacoes);
+        }
+
+        if ($this->turnos !== null && ! empty($this->turnos)) {
+            $resumo['Turnos'] = implode(', ', $this->turnos);
+        }
+
+        if ($this->instituicaoId !== null) {
+            $resumo['Instituição'] = $this->instituicaoId;
+        }
+
+        if ($this->unidadeId !== null) {
+            $resumo['Unidade'] = $this->unidadeId;
+        }
+
+        if ($this->moduloId !== null) {
+            $resumo['Módulo'] = $this->moduloId;
+        }
+
+        if ($this->andarId !== null) {
+            $resumo['Andar'] = $this->andarId;
+        }
+
+        if ($this->espacoId !== null) {
+            $resumo['Espaço'] = $this->espacoId;
+        }
+
+        if ($this->setorId !== null) {
+            $resumo['Setor'] = $this->setorId;
+        }
+
+        return $resumo;
+    }
+}

--- a/app/Services/Relatorio/Exporters/CsvExporter.php
+++ b/app/Services/Relatorio/Exporters/CsvExporter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Exporters;
+
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use App\Services\Relatorio\Exports\RelatorioExport;
+use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+final class CsvExporter implements ExporterInterface
+{
+    public function suporta(FormatoRelatorioEnum $formato): bool
+    {
+        return $formato === FormatoRelatorioEnum::CSV;
+    }
+
+    public function exportar(DadosRelatorio $dados, string $nomeArquivo): BinaryFileResponse
+    {
+        return Excel::download(new RelatorioExport($dados), $nomeArquivo, \Maatwebsite\Excel\Excel::CSV);
+    }
+}

--- a/app/Services/Relatorio/Exporters/ExporterFactory.php
+++ b/app/Services/Relatorio/Exporters/ExporterFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Exporters;
+
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use RuntimeException;
+
+final class ExporterFactory
+{
+    public function __construct(
+        private iterable $exporters,
+    ) {}
+
+    public function make(FormatoRelatorioEnum $formato): ExporterInterface
+    {
+        foreach ($this->exporters as $exporter) {
+            if ($exporter->suporta($formato)) {
+                return $exporter;
+            }
+        }
+
+        throw new RuntimeException("Formato não suportado: {$formato->value}");
+    }
+}

--- a/app/Services/Relatorio/Exporters/ExporterInterface.php
+++ b/app/Services/Relatorio/Exporters/ExporterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Exporters;
+
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+interface ExporterInterface
+{
+    public function suporta(FormatoRelatorioEnum $formato): bool;
+
+    public function exportar(DadosRelatorio $dados, string $nomeArquivo): BinaryFileResponse|StreamedResponse;
+}

--- a/app/Services/Relatorio/Exporters/PdfExporter.php
+++ b/app/Services/Relatorio/Exporters/PdfExporter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Exporters;
+
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class PdfExporter implements ExporterInterface
+{
+    public function suporta(FormatoRelatorioEnum $formato): bool
+    {
+        return $formato === FormatoRelatorioEnum::PDF;
+    }
+
+    public function exportar(DadosRelatorio $dados, string $nomeArquivo): StreamedResponse
+    {
+        $orientacao = count($dados->colunas) > 6 ? 'landscape' : config('relatorios.pdf.orientacao_padrao', 'portrait');
+
+        $pdf = Pdf::loadView('relatorios.pdf.tabela', ['dados' => $dados]);
+        $pdf->setPaper(config('relatorios.pdf.tamanho', 'A4'), $orientacao);
+
+        return response()->streamDownload(
+            function () use ($pdf) {
+                echo $pdf->output();
+            },
+            $nomeArquivo,
+            ['Content-Type' => 'application/pdf'],
+        );
+    }
+}

--- a/app/Services/Relatorio/Exporters/XlsxExporter.php
+++ b/app/Services/Relatorio/Exporters/XlsxExporter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Exporters;
+
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use App\Services\Relatorio\Exports\RelatorioExport;
+use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+final class XlsxExporter implements ExporterInterface
+{
+    public function suporta(FormatoRelatorioEnum $formato): bool
+    {
+        return $formato === FormatoRelatorioEnum::XLSX;
+    }
+
+    public function exportar(DadosRelatorio $dados, string $nomeArquivo): BinaryFileResponse
+    {
+        return Excel::download(new RelatorioExport($dados), $nomeArquivo, \Maatwebsite\Excel\Excel::XLSX);
+    }
+}

--- a/app/Services/Relatorio/Exports/RelatorioExport.php
+++ b/app/Services/Relatorio/Exports/RelatorioExport.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Exports;
+
+use App\Services\Relatorio\Data\DadosRelatorio;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithColumnFormatting;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+final class RelatorioExport implements FromArray, WithColumnFormatting, WithHeadings, WithMapping, WithStyles, WithTitle
+{
+    public function __construct(
+        private DadosRelatorio $dados,
+    ) {}
+
+    public function array(): array
+    {
+        return $this->dados->linhas;
+    }
+
+    public function headings(): array
+    {
+        return array_map(fn ($coluna) => $coluna->rotulo, $this->dados->colunas);
+    }
+
+    public function map($linha): array
+    {
+        return array_map(fn ($coluna) => $linha[$coluna->chave] ?? '', $this->dados->colunas);
+    }
+
+    public function columnFormats(): array
+    {
+        $formats = [];
+
+        foreach ($this->dados->colunas as $index => $coluna) {
+            $columnLetter = $this->columnIndexToLetter($index);
+
+            $formats[$columnLetter] = match ($coluna->tipo) {
+                'date' => NumberFormat::FORMAT_DATE_DDMMYYYY,
+                'datetime' => NumberFormat::FORMAT_DATE_DATETIME,
+                'integer' => NumberFormat::FORMAT_NUMBER,
+                'decimal' => NumberFormat::FORMAT_NUMBER_COMMA_SEPARATED1,
+                default => NumberFormat::FORMAT_TEXT,
+            };
+        }
+
+        return $formats;
+    }
+
+    public function styles(Worksheet $sheet): array
+    {
+        return [
+            1 => [
+                'font' => ['bold' => true],
+                'fill' => [
+                    'fillType' => Fill::FILL_SOLID,
+                    'startColor' => ['rgb' => 'F0F0F0'],
+                ],
+            ],
+        ];
+    }
+
+    public function title(): string
+    {
+        return mb_substr($this->dados->titulo, 0, 31);
+    }
+
+    private function columnIndexToLetter(int $index): string
+    {
+        $letter = '';
+        $index++;
+
+        while ($index > 0) {
+            $mod = ($index - 1) % 26;
+            $letter = chr(65 + $mod).$letter;
+            $index = (int) (($index - $mod) / 26);
+        }
+
+        return $letter;
+    }
+}

--- a/app/Services/Relatorio/RelatorioFactory.php
+++ b/app/Services/Relatorio/RelatorioFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio;
+
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Services\Relatorio\Reports\RelatorioInterface;
+use Illuminate\Contracts\Container\Container;
+use RuntimeException;
+
+final class RelatorioFactory
+{
+    public function __construct(
+        private Container $container,
+    ) {}
+
+    public function make(TipoRelatorioEnum $tipo): RelatorioInterface
+    {
+        $classe = config("relatorios.tipos.{$tipo->value}");
+
+        if (! $classe || ! class_exists($classe)) {
+            throw new RuntimeException("Relatório não registrado: {$tipo->value}");
+        }
+
+        return $this->container->make($classe);
+    }
+}

--- a/app/Services/Relatorio/RelatorioService.php
+++ b/app/Services/Relatorio/RelatorioService.php
@@ -6,6 +6,7 @@ namespace App\Services\Relatorio;
 
 use App\Enums\Relatorio\FormatoRelatorioEnum;
 use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Models\Espaco;
 use App\Models\User;
 use App\Services\Relatorio\Data\DadosRelatorio;
 use App\Services\Relatorio\Data\FiltrosRelatorio;
@@ -22,19 +23,99 @@ final class RelatorioService
 
     public function gerar(User $usuario, TipoRelatorioEnum $tipo, FormatoRelatorioEnum $formato, FiltrosRelatorio $filtros): BinaryFileResponse|StreamedResponse
     {
-        if (! $usuario->hasPermissionTo($tipo->permissao())) {
-            abort(403, 'Tipo de relatório não disponível para este perfil.');
-        }
-
-        $filtros = $this->aplicarEscopo($usuario, $filtros);
-
-        $dados = $this->relatorios->make($tipo)->gerar($usuario, $filtros);
+        $dados = $this->agregar($usuario, $tipo, $filtros);
 
         $this->validarLimites($dados, $formato);
 
         $nomeArquivo = sprintf('%s-%s.%s', $tipo->value, now()->format('Ymd-His'), $formato->value);
 
         return $this->exporters->make($formato)->exportar($dados, $nomeArquivo);
+    }
+
+    public function agregar(User $usuario, TipoRelatorioEnum $tipo, FiltrosRelatorio $filtros): DadosRelatorio
+    {
+        if (! $usuario->hasPermissionTo($tipo->permissao())) {
+            abort(403, 'Tipo de relatório não disponível para este perfil.');
+        }
+
+        $filtros = $this->aplicarEscopo($usuario, $filtros);
+
+        return $this->relatorios->make($tipo)->gerar($usuario, $filtros);
+    }
+
+    /**
+     * Opcoes de localizacao para os filtros do inventario, ja restritas ao
+     * escopo do usuario. Cada nivel carrega a chave do pai para permitir o
+     * encadeamento dos comboboxes no frontend.
+     *
+     * @return array{
+     *     unidades: array<int, array{id: int, nome: string}>,
+     *     modulos: array<int, array{id: int, nome: string, unidade_id: int}>,
+     *     andares: array<int, array{id: int, nome: string, modulo_id: int}>,
+     *     espacos: array<int, array{id: int, nome: string, andar_id: int}>
+     * }
+     */
+    public function opcoesInventario(User $usuario): array
+    {
+        $espacosQuery = Espaco::query()->with('andar.modulo.unidade');
+
+        if ($usuario->hasRole('institucional')) {
+            $instituicaoId = $usuario->setor->unidade->instituicao_id;
+            $espacosQuery->whereHas(
+                'andar.modulo.unidade',
+                fn ($u) => $u->where('instituicao_id', $instituicaoId)
+            );
+        } elseif ($usuario->hasRole('gestor')) {
+            $agendaIds = $usuario->agendas()->pluck('id')->all();
+            $espacosQuery->whereHas('agendas', fn ($q) => $q->whereIn('id', $agendaIds));
+        } else {
+            abort(403);
+        }
+
+        $espacos = $espacosQuery->get()->filter(
+            fn (Espaco $espaco) => $espaco->andar?->modulo?->unidade !== null
+        );
+
+        $unidades = [];
+        $modulos = [];
+        $andares = [];
+        $listaEspacos = [];
+
+        foreach ($espacos as $espaco) {
+            $andar = $espaco->andar;
+            $modulo = $andar->modulo;
+            $unidade = $modulo->unidade;
+
+            $unidades[$unidade->id] = ['id' => $unidade->id, 'nome' => $unidade->nome];
+            $modulos[$modulo->id] = [
+                'id' => $modulo->id,
+                'nome' => $modulo->nome,
+                'unidade_id' => $unidade->id,
+            ];
+            $andares[$andar->id] = [
+                'id' => $andar->id,
+                'nome' => $andar->nome,
+                'modulo_id' => $modulo->id,
+            ];
+            $listaEspacos[$espaco->id] = [
+                'id' => $espaco->id,
+                'nome' => $espaco->nome,
+                'andar_id' => $andar->id,
+            ];
+        }
+
+        $ordenarPorNome = function (array $itens): array {
+            usort($itens, fn ($a, $b) => strnatcasecmp($a['nome'], $b['nome']));
+
+            return $itens;
+        };
+
+        return [
+            'unidades' => $ordenarPorNome(array_values($unidades)),
+            'modulos' => $ordenarPorNome(array_values($modulos)),
+            'andares' => $ordenarPorNome(array_values($andares)),
+            'espacos' => $ordenarPorNome(array_values($listaEspacos)),
+        ];
     }
 
     private function aplicarEscopo(User $usuario, FiltrosRelatorio $filtros): FiltrosRelatorio

--- a/app/Services/Relatorio/RelatorioService.php
+++ b/app/Services/Relatorio/RelatorioService.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio;
+
+use App\Enums\Relatorio\FormatoRelatorioEnum;
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Models\User;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use App\Services\Relatorio\Data\FiltrosRelatorio;
+use App\Services\Relatorio\Exporters\ExporterFactory;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+final class RelatorioService
+{
+    public function __construct(
+        private RelatorioFactory $relatorios,
+        private ExporterFactory $exporters,
+    ) {}
+
+    public function gerar(User $usuario, TipoRelatorioEnum $tipo, FormatoRelatorioEnum $formato, FiltrosRelatorio $filtros): BinaryFileResponse|StreamedResponse
+    {
+        if (! $usuario->hasPermissionTo($tipo->permissao())) {
+            abort(403, 'Tipo de relatório não disponível para este perfil.');
+        }
+
+        $filtros = $this->aplicarEscopo($usuario, $filtros);
+
+        $dados = $this->relatorios->make($tipo)->gerar($usuario, $filtros);
+
+        $this->validarLimites($dados, $formato);
+
+        $nomeArquivo = sprintf('%s-%s.%s', $tipo->value, now()->format('Ymd-His'), $formato->value);
+
+        return $this->exporters->make($formato)->exportar($dados, $nomeArquivo);
+    }
+
+    private function aplicarEscopo(User $usuario, FiltrosRelatorio $filtros): FiltrosRelatorio
+    {
+        if ($usuario->hasRole('institucional')) {
+            return new FiltrosRelatorio(
+                dataInicio: $filtros->dataInicio,
+                dataFim: $filtros->dataFim,
+                situacoes: $filtros->situacoes,
+                turnos: $filtros->turnos,
+                instituicaoId: $usuario->setor->unidade->instituicao_id,
+                unidadeId: $filtros->unidadeId,
+                moduloId: $filtros->moduloId,
+                andarId: $filtros->andarId,
+                espacoId: $filtros->espacoId,
+                setorId: $filtros->setorId,
+                agendaIds: $filtros->agendaIds,
+            );
+        }
+
+        if ($usuario->hasRole('gestor')) {
+            return new FiltrosRelatorio(
+                dataInicio: $filtros->dataInicio,
+                dataFim: $filtros->dataFim,
+                situacoes: $filtros->situacoes,
+                turnos: $filtros->turnos,
+                instituicaoId: null,
+                unidadeId: null,
+                moduloId: null,
+                andarId: null,
+                espacoId: $filtros->espacoId,
+                setorId: null,
+                agendaIds: $usuario->agendas()->pluck('id')->all(),
+            );
+        }
+
+        abort(403);
+    }
+
+    private function validarLimites(DadosRelatorio $dados, FormatoRelatorioEnum $formato): void
+    {
+        $totalLinhas = $dados->totalLinhas();
+        $limite = $formato === FormatoRelatorioEnum::PDF
+            ? config('relatorios.limites.max_linhas_pdf')
+            : config('relatorios.limites.max_linhas_csv_xlsx');
+
+        if ($totalLinhas > $limite) {
+            abort(422, "Relatório excede o limite de {$limite} linhas para este formato. Refine os filtros.");
+        }
+    }
+}

--- a/app/Services/Relatorio/Reports/IndicadoresConsolidadosRelatorio.php
+++ b/app/Services/Relatorio/Reports/IndicadoresConsolidadosRelatorio.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Relatorio\Reports;
 
 use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Enums\SituacaoReserva\SituacaoReservaEnum;
 use App\Models\Espaco;
 use App\Models\Horario;
 use App\Models\Reserva;
@@ -46,44 +47,42 @@ final class IndicadoresConsolidadosRelatorio implements RelatorioInterface
 
         $totalReservas = $reservasQuery->count();
 
-        $distribuicaoSituacoes = $reservasQuery->get()
+        $distribuicaoSituacoes = (clone $reservasQuery)
+            ->selectRaw('situacao, count(*) as total')
             ->groupBy('situacao')
-            ->map(fn ($group) => $group->count())
+            ->pluck('total', 'situacao')
+            ->map(fn ($total) => (int) $total)
             ->all();
 
         $top5Espacos = Horario::query()
-            ->where('situacao', 'deferida')
+            ->where('horarios.situacao', 'deferida')
             ->whereHas('agenda.espaco.andar.modulo.unidade', fn ($q) => $q->where('instituicao_id', $instituicaoId))
-            ->with('agenda.espaco')
+            ->join('agendas', 'horarios.agenda_id', '=', 'agendas.id')
+            ->join('espacos', 'agendas.espaco_id', '=', 'espacos.id')
+            ->groupBy('espacos.id', 'espacos.nome')
+            ->selectRaw('espacos.nome as nome, count(*) as count')
+            ->orderByDesc('count')
+            ->limit(5)
             ->get()
-            ->groupBy(fn ($h) => $h->agenda->espaco_id)
-            ->map(function ($horarios) {
-                $espaco = $horarios->first()->agenda->espaco;
-
-                return [
-                    'nome' => $espaco->nome,
-                    'count' => $horarios->count(),
-                ];
-            })
-            ->sortByDesc('count')
-            ->take(5)
+            ->map(fn ($row) => [
+                'nome' => $row->getAttribute('nome'),
+                'count' => (int) $row->getAttribute('count'),
+            ])
             ->all();
 
         $top5Setores = Reserva::query()
             ->whereHas('user.setor.unidade', fn ($q) => $q->where('instituicao_id', $instituicaoId))
-            ->with('user.setor')
+            ->join('users', 'reservas.user_id', '=', 'users.id')
+            ->join('setors', 'users.setor_id', '=', 'setors.id')
+            ->groupBy('setors.id', 'setors.nome')
+            ->selectRaw('setors.nome as nome, count(*) as count')
+            ->orderByDesc('count')
+            ->limit(5)
             ->get()
-            ->groupBy(fn ($r) => $r->user->setor_id)
-            ->map(function ($reservas) {
-                $setor = $reservas->first()->user->setor;
-
-                return [
-                    'nome' => $setor->nome ?? '—',
-                    'count' => $reservas->count(),
-                ];
-            })
-            ->sortByDesc('count')
-            ->take(5)
+            ->map(fn ($row) => [
+                'nome' => $row->getAttribute('nome') ?? '—',
+                'count' => (int) $row->getAttribute('count'),
+            ])
             ->all();
 
         $linhas = [
@@ -94,7 +93,7 @@ final class IndicadoresConsolidadosRelatorio implements RelatorioInterface
 
         foreach ($distribuicaoSituacoes as $situacao => $count) {
             $linhas[] = [
-                'metrica' => 'Reservas '.ucfirst(str_replace('_', ' ', $situacao)),
+                'metrica' => 'Reservas '.SituacaoReservaEnum::labelDe((string) $situacao),
                 'valor' => $count,
             ];
         }

--- a/app/Services/Relatorio/Reports/IndicadoresConsolidadosRelatorio.php
+++ b/app/Services/Relatorio/Reports/IndicadoresConsolidadosRelatorio.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Reports;
+
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Models\Espaco;
+use App\Models\Horario;
+use App\Models\Reserva;
+use App\Models\User;
+use App\Services\Relatorio\Data\ColunaRelatorio;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use App\Services\Relatorio\Data\FiltrosRelatorio;
+use Carbon\CarbonImmutable;
+
+final class IndicadoresConsolidadosRelatorio implements RelatorioInterface
+{
+    public function gerar(User $usuario, FiltrosRelatorio $filtros): DadosRelatorio
+    {
+        $instituicaoId = $filtros->instituicaoId;
+
+        $totalEspacos = Espaco::query()
+            ->whereHas('andar.modulo.unidade', fn ($q) => $q->where('instituicao_id', $instituicaoId))
+            ->count();
+
+        $totalGestores = User::query()
+            ->whereHas('agendas.espaco.andar.modulo.unidade', fn ($q) => $q->where('instituicao_id', $instituicaoId))
+            ->distinct('id')
+            ->count();
+
+        $reservasQuery = Reserva::query()
+            ->whereHas('horarios.agenda.espaco.andar.modulo.unidade', fn ($q) => $q->where('instituicao_id', $instituicaoId));
+
+        if ($filtros->dataInicio !== null || $filtros->dataFim !== null) {
+            $reservasQuery->whereHas('horarios', function ($h) use ($filtros) {
+                if ($filtros->dataInicio !== null && $filtros->dataFim !== null) {
+                    $h->whereBetween('data', [$filtros->dataInicio, $filtros->dataFim]);
+                } elseif ($filtros->dataInicio !== null) {
+                    $h->where('data', '>=', $filtros->dataInicio);
+                } elseif ($filtros->dataFim !== null) {
+                    $h->where('data', '<=', $filtros->dataFim);
+                }
+            });
+        }
+
+        $totalReservas = $reservasQuery->count();
+
+        $distribuicaoSituacoes = $reservasQuery->get()
+            ->groupBy('situacao')
+            ->map(fn ($group) => $group->count())
+            ->all();
+
+        $top5Espacos = Horario::query()
+            ->where('situacao', 'deferida')
+            ->whereHas('agenda.espaco.andar.modulo.unidade', fn ($q) => $q->where('instituicao_id', $instituicaoId))
+            ->with('agenda.espaco')
+            ->get()
+            ->groupBy(fn ($h) => $h->agenda->espaco_id)
+            ->map(function ($horarios) {
+                $espaco = $horarios->first()->agenda->espaco;
+
+                return [
+                    'nome' => $espaco->nome,
+                    'count' => $horarios->count(),
+                ];
+            })
+            ->sortByDesc('count')
+            ->take(5)
+            ->all();
+
+        $top5Setores = Reserva::query()
+            ->whereHas('user.setor.unidade', fn ($q) => $q->where('instituicao_id', $instituicaoId))
+            ->with('user.setor')
+            ->get()
+            ->groupBy(fn ($r) => $r->user->setor_id)
+            ->map(function ($reservas) {
+                $setor = $reservas->first()->user->setor;
+
+                return [
+                    'nome' => $setor->nome ?? '—',
+                    'count' => $reservas->count(),
+                ];
+            })
+            ->sortByDesc('count')
+            ->take(5)
+            ->all();
+
+        $linhas = [
+            ['metrica' => 'Total de Espaços', 'valor' => $totalEspacos],
+            ['metrica' => 'Total de Gestores', 'valor' => $totalGestores],
+            ['metrica' => 'Total de Reservas', 'valor' => $totalReservas],
+        ];
+
+        foreach ($distribuicaoSituacoes as $situacao => $count) {
+            $linhas[] = [
+                'metrica' => 'Reservas '.ucfirst(str_replace('_', ' ', $situacao)),
+                'valor' => $count,
+            ];
+        }
+
+        $linhas[] = ['metrica' => '— Top 5 Espaços —', 'valor' => ''];
+
+        foreach ($top5Espacos as $espaco) {
+            $linhas[] = [
+                'metrica' => $espaco['nome'],
+                'valor' => $espaco['count'],
+            ];
+        }
+
+        $linhas[] = ['metrica' => '— Top 5 Setores —', 'valor' => ''];
+
+        foreach ($top5Setores as $setor) {
+            $linhas[] = [
+                'metrica' => $setor['nome'],
+                'valor' => $setor['count'],
+            ];
+        }
+
+        $colunas = [
+            new ColunaRelatorio('metrica', 'Métrica', 'string', 40),
+            new ColunaRelatorio('valor', 'Valor', 'string', 15),
+        ];
+
+        $sumario = [
+            'Total de Espaços' => $totalEspacos,
+            'Total de Gestores' => $totalGestores,
+            'Total de Reservas' => $totalReservas,
+        ];
+
+        return new DadosRelatorio(
+            tipo: TipoRelatorioEnum::INDICADORES_CONSOLIDADOS,
+            titulo: TipoRelatorioEnum::INDICADORES_CONSOLIDADOS->titulo(),
+            subtitulo: 'Visão Consolidada da Instituição',
+            colunas: $colunas,
+            linhas: $linhas,
+            sumario: $sumario,
+            filtrosAplicados: $filtros->resumo(),
+            geradoPor: $usuario->name,
+            geradoEm: CarbonImmutable::now(),
+        );
+    }
+}

--- a/app/Services/Relatorio/Reports/InventarioEspacosRelatorio.php
+++ b/app/Services/Relatorio/Reports/InventarioEspacosRelatorio.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Reports;
+
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Models\Espaco;
+use App\Models\User;
+use App\Services\Relatorio\Data\ColunaRelatorio;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use App\Services\Relatorio\Data\FiltrosRelatorio;
+use Carbon\CarbonImmutable;
+
+final class InventarioEspacosRelatorio implements RelatorioInterface
+{
+    public function gerar(User $usuario, FiltrosRelatorio $filtros): DadosRelatorio
+    {
+        $query = Espaco::query()->with(['andar.modulo.unidade', 'agendas.user']);
+
+        if ($filtros->agendaIds !== null) {
+            $query->whereHas('agendas', fn ($q) => $q->whereIn('id', $filtros->agendaIds));
+        } elseif ($filtros->instituicaoId !== null) {
+            $query->whereHas('andar.modulo.unidade', fn ($q) => $q->where('instituicao_id', $filtros->instituicaoId));
+        }
+
+        if ($filtros->unidadeId !== null) {
+            $query->whereHas('andar.modulo.unidade', fn ($q) => $q->where('id', $filtros->unidadeId));
+        }
+
+        if ($filtros->moduloId !== null) {
+            $query->whereHas('andar.modulo', fn ($q) => $q->where('id', $filtros->moduloId));
+        }
+
+        if ($filtros->andarId !== null) {
+            $query->whereHas('andar', fn ($q) => $q->where('id', $filtros->andarId));
+        }
+
+        if ($filtros->espacoId !== null) {
+            $query->where('id', $filtros->espacoId);
+        }
+
+        $espacos = $query->get();
+
+        $linhas = $espacos->map(function (Espaco $espaco) {
+            $gestores = $espaco->agendas
+                ->pluck('user.name')
+                ->unique()
+                ->join(', ');
+
+            return [
+                'id' => $espaco->id,
+                'nome' => $espaco->nome,
+                'capacidade_pessoas' => $espaco->capacidade_pessoas,
+                'unidade' => $espaco->andar->modulo->unidade->nome ?? '—',
+                'modulo' => $espaco->andar->modulo->nome ?? '—',
+                'andar' => $espaco->andar->nome ?? '—',
+                'total_agendas' => $espaco->agendas->count(),
+                'gestores' => $gestores ?: '—',
+            ];
+        })->toArray();
+
+        $colunas = [
+            new ColunaRelatorio('id', 'ID', 'integer', 5),
+            new ColunaRelatorio('nome', 'Nome', 'string', 20),
+            new ColunaRelatorio('capacidade_pessoas', 'Capacidade', 'integer', 10),
+            new ColunaRelatorio('unidade', 'Unidade', 'string', 15),
+            new ColunaRelatorio('modulo', 'Módulo', 'string', 15),
+            new ColunaRelatorio('andar', 'Andar', 'string', 10),
+            new ColunaRelatorio('total_agendas', 'Agendas', 'integer', 8),
+            new ColunaRelatorio('gestores', 'Gestores', 'string', 25),
+        ];
+
+        $capacidadeTotal = $espacos->sum('capacidade_pessoas');
+        $mediaCapacidade = count($linhas) > 0 ? $capacidadeTotal / count($linhas) : 0;
+        $totalGestores = $espacos
+            ->flatMap(fn ($e) => $e->agendas->pluck('user.id'))
+            ->unique()
+            ->count();
+
+        $sumario = [
+            'Total de Espaços' => count($linhas),
+            'Capacidade Total' => $capacidadeTotal,
+            'Média de Capacidade' => number_format($mediaCapacidade, 0),
+            'Total de Gestores Únicos' => $totalGestores,
+        ];
+
+        return new DadosRelatorio(
+            tipo: TipoRelatorioEnum::INVENTARIO_ESPACOS,
+            titulo: TipoRelatorioEnum::INVENTARIO_ESPACOS->titulo(),
+            subtitulo: '',
+            colunas: $colunas,
+            linhas: $linhas,
+            sumario: $sumario,
+            filtrosAplicados: $filtros->resumo(),
+            geradoPor: $usuario->name,
+            geradoEm: CarbonImmutable::now(),
+        );
+    }
+}

--- a/app/Services/Relatorio/Reports/OcupacaoEspacosRelatorio.php
+++ b/app/Services/Relatorio/Reports/OcupacaoEspacosRelatorio.php
@@ -5,30 +5,25 @@ declare(strict_types=1);
 namespace App\Services\Relatorio\Reports;
 
 use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Models\Espaco;
 use App\Models\Horario;
 use App\Models\User;
 use App\Services\Relatorio\Data\ColunaRelatorio;
 use App\Services\Relatorio\Data\DadosRelatorio;
 use App\Services\Relatorio\Data\FiltrosRelatorio;
 use Carbon\CarbonImmutable;
+use Carbon\CarbonPeriod;
 
 final class OcupacaoEspacosRelatorio implements RelatorioInterface
 {
     public function gerar(User $usuario, FiltrosRelatorio $filtros): DadosRelatorio
     {
+        $inicio = $filtros->dataInicio ?? CarbonImmutable::now()->startOfMonth();
+        $fim = $filtros->dataFim ?? CarbonImmutable::now()->endOfMonth();
+
         $query = Horario::query()
             ->where('situacao', 'deferida')
-            ->with('agenda.espaco.andar.modulo.unidade');
-
-        if ($filtros->dataInicio !== null || $filtros->dataFim !== null) {
-            if ($filtros->dataInicio !== null && $filtros->dataFim !== null) {
-                $query->whereBetween('data', [$filtros->dataInicio, $filtros->dataFim]);
-            } elseif ($filtros->dataInicio !== null) {
-                $query->where('data', '>=', $filtros->dataInicio);
-            } elseif ($filtros->dataFim !== null) {
-                $query->where('data', '<=', $filtros->dataFim);
-            }
-        }
+            ->whereBetween('data', [$inicio, $fim]);
 
         if ($filtros->agendaIds !== null) {
             $query->whereIn('agenda_id', $filtros->agendaIds);
@@ -40,51 +35,71 @@ final class OcupacaoEspacosRelatorio implements RelatorioInterface
             });
         }
 
-        $horarios = $query->get();
+        if ($filtros->turnos !== null) {
+            $query->whereHas('agenda', fn ($q) => $q->whereIn('turno', $filtros->turnos));
+        }
 
-        $ocupacaoPorEspaco = $horarios->groupBy(function ($h) {
-            return $h->agenda->espaco_id;
-        })->map(function ($horariosEspaco) {
-            $espaco = $horariosEspaco->first()->agenda->espaco;
+        // Conta slots distintos, nao registros: o mesmo par (data, horario_inicio)
+        // pode ter varias linhas em horarios para uma unica reserva, e contar as
+        // repeticoes levava a taxa de ocupacao acima de 100%.
+        $contagens = $query
+            ->join('agendas', 'horarios.agenda_id', '=', 'agendas.id')
+            ->groupBy('agendas.espaco_id')
+            ->selectRaw('agendas.espaco_id as espaco_id, count(distinct (horarios.data, horarios.horario_inicio)) as total')
+            ->pluck('total', 'espaco_id');
 
-            return [
-                'espaco_id' => $espaco->id,
-                'nome_espaco' => $espaco->nome,
-                'capacidade_pessoas' => $espaco->capacidade_pessoas,
-                'localizacao' => sprintf(
-                    '%s / %s / %s',
-                    $espaco->andar->nome ?? '—',
-                    $espaco->andar->modulo->nome ?? '—',
-                    $espaco->andar->modulo->unidade->nome ?? '—',
-                ),
-                'total_horarios_ocupados' => $horariosEspaco->count(),
-            ];
-        })->values();
+        $espacos = Espaco::query()
+            ->with('andar.modulo.unidade')
+            ->whereIn('id', $contagens->keys())
+            ->get()
+            ->keyBy('id');
 
-        $linhas = $ocupacaoPorEspaco->map(function ($ocupacao) {
-            $totalDias = 22;
-            $turnosPorAgenda = 3;
-            $totalCapacidade = $totalDias * $turnosPorAgenda;
+        $linhas = $contagens
+            ->filter(fn ($total, $espacoId) => $espacos->has($espacoId))
+            ->map(function ($total, $espacoId) use ($espacos, $filtros, $inicio, $fim) {
+                $espaco = $espacos->get($espacoId);
 
-            $taxaOcupacao = ($ocupacao['total_horarios_ocupados'] / $totalCapacidade) * 100;
+                $turnosSel = $filtros->turnos ?: ['manha', 'tarde', 'noite'];
+                $slots = array_sum(array_map(
+                    fn ($t) => config("relatorios.slots_por_turno.$t", 0),
+                    $turnosSel
+                ));
+                $diasLetivos = 0;
+                $periodo = CarbonPeriod::create($inicio, $fim);
+                foreach ($periodo as $dia) {
+                    if (! $dia->isSunday()) {
+                        $diasLetivos++;
+                    }
+                }
+                $capacidade = $diasLetivos * $slots;
+                $totalOcupados = (int) $total;
+                $taxaOcupacao = $capacidade > 0 ? ($totalOcupados / $capacidade) * 100 : 0;
 
-            return [
-                'espaco_id' => $ocupacao['espaco_id'],
-                'nome_espaco' => $ocupacao['nome_espaco'],
-                'capacidade_pessoas' => $ocupacao['capacidade_pessoas'],
-                'localizacao' => $ocupacao['localizacao'],
-                'total_horarios_ocupados' => $ocupacao['total_horarios_ocupados'],
-                'total_dias_no_periodo' => $totalDias,
-                'taxa_ocupacao' => number_format($taxaOcupacao, 2, '.', '').'%',
-            ];
-        })->toArray();
+                return [
+                    'espaco_id' => $espaco->id,
+                    'nome_espaco' => $espaco->nome,
+                    'capacidade_pessoas' => $espaco->capacidade_pessoas,
+                    'localizacao' => sprintf(
+                        '%s / %s / %s',
+                        $espaco->andar->nome ?? '—',
+                        $espaco->andar->modulo->nome ?? '—',
+                        $espaco->andar->modulo->unidade->nome ?? '—',
+                    ),
+                    'total_horarios_ocupados' => $totalOcupados,
+                    'total_dias_no_periodo' => $diasLetivos,
+                    'taxa_ocupacao' => number_format($taxaOcupacao, 2, '.', '').'%',
+                    'taxa_ocupacao_num' => $taxaOcupacao,
+                ];
+            })
+            ->values()
+            ->toArray();
 
         $colunas = [
             new ColunaRelatorio('espaco_id', 'ID Espaço', 'integer', 8),
             new ColunaRelatorio('nome_espaco', 'Espaço', 'string', 20),
             new ColunaRelatorio('capacidade_pessoas', 'Capacidade', 'integer', 10),
             new ColunaRelatorio('localizacao', 'Localização', 'string', 25),
-            new ColunaRelatorio('total_horarios_ocupados', 'Horários', 'integer', 8),
+            new ColunaRelatorio('total_horarios_ocupados', 'Slots', 'integer', 8),
             new ColunaRelatorio('total_dias_no_periodo', 'Dias', 'integer', 6),
             new ColunaRelatorio('taxa_ocupacao', 'Taxa %', 'string', 8),
         ];

--- a/app/Services/Relatorio/Reports/OcupacaoEspacosRelatorio.php
+++ b/app/Services/Relatorio/Reports/OcupacaoEspacosRelatorio.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Reports;
+
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Models\Horario;
+use App\Models\User;
+use App\Services\Relatorio\Data\ColunaRelatorio;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use App\Services\Relatorio\Data\FiltrosRelatorio;
+use Carbon\CarbonImmutable;
+
+final class OcupacaoEspacosRelatorio implements RelatorioInterface
+{
+    public function gerar(User $usuario, FiltrosRelatorio $filtros): DadosRelatorio
+    {
+        $query = Horario::query()
+            ->where('situacao', 'deferida')
+            ->with('agenda.espaco.andar.modulo.unidade');
+
+        if ($filtros->dataInicio !== null || $filtros->dataFim !== null) {
+            if ($filtros->dataInicio !== null && $filtros->dataFim !== null) {
+                $query->whereBetween('data', [$filtros->dataInicio, $filtros->dataFim]);
+            } elseif ($filtros->dataInicio !== null) {
+                $query->where('data', '>=', $filtros->dataInicio);
+            } elseif ($filtros->dataFim !== null) {
+                $query->where('data', '<=', $filtros->dataFim);
+            }
+        }
+
+        if ($filtros->agendaIds !== null) {
+            $query->whereIn('agenda_id', $filtros->agendaIds);
+        }
+
+        if ($filtros->instituicaoId !== null && $filtros->agendaIds === null) {
+            $query->whereHas('agenda.espaco.andar.modulo.unidade', function ($u) use ($filtros) {
+                $u->where('instituicao_id', $filtros->instituicaoId);
+            });
+        }
+
+        $horarios = $query->get();
+
+        $ocupacaoPorEspaco = $horarios->groupBy(function ($h) {
+            return $h->agenda->espaco_id;
+        })->map(function ($horariosEspaco) {
+            $espaco = $horariosEspaco->first()->agenda->espaco;
+
+            return [
+                'espaco_id' => $espaco->id,
+                'nome_espaco' => $espaco->nome,
+                'capacidade_pessoas' => $espaco->capacidade_pessoas,
+                'localizacao' => sprintf(
+                    '%s / %s / %s',
+                    $espaco->andar->nome ?? '—',
+                    $espaco->andar->modulo->nome ?? '—',
+                    $espaco->andar->modulo->unidade->nome ?? '—',
+                ),
+                'total_horarios_ocupados' => $horariosEspaco->count(),
+            ];
+        })->values();
+
+        $linhas = $ocupacaoPorEspaco->map(function ($ocupacao) {
+            $totalDias = 22;
+            $turnosPorAgenda = 3;
+            $totalCapacidade = $totalDias * $turnosPorAgenda;
+
+            $taxaOcupacao = ($ocupacao['total_horarios_ocupados'] / $totalCapacidade) * 100;
+
+            return [
+                'espaco_id' => $ocupacao['espaco_id'],
+                'nome_espaco' => $ocupacao['nome_espaco'],
+                'capacidade_pessoas' => $ocupacao['capacidade_pessoas'],
+                'localizacao' => $ocupacao['localizacao'],
+                'total_horarios_ocupados' => $ocupacao['total_horarios_ocupados'],
+                'total_dias_no_periodo' => $totalDias,
+                'taxa_ocupacao' => number_format($taxaOcupacao, 2, '.', '').'%',
+            ];
+        })->toArray();
+
+        $colunas = [
+            new ColunaRelatorio('espaco_id', 'ID Espaço', 'integer', 8),
+            new ColunaRelatorio('nome_espaco', 'Espaço', 'string', 20),
+            new ColunaRelatorio('capacidade_pessoas', 'Capacidade', 'integer', 10),
+            new ColunaRelatorio('localizacao', 'Localização', 'string', 25),
+            new ColunaRelatorio('total_horarios_ocupados', 'Horários', 'integer', 8),
+            new ColunaRelatorio('total_dias_no_periodo', 'Dias', 'integer', 6),
+            new ColunaRelatorio('taxa_ocupacao', 'Taxa %', 'string', 8),
+        ];
+
+        $mediaTaxa = 0;
+        if (count($linhas) > 0) {
+            $totalTaxa = 0;
+            foreach ($linhas as $linha) {
+                $totalTaxa += (float) str_replace('%', '', $linha['taxa_ocupacao']);
+            }
+            $mediaTaxa = $totalTaxa / count($linhas);
+        }
+
+        $sumario = [
+            'Total de Espaços' => count($linhas),
+            'Média de Taxa de Ocupação' => number_format($mediaTaxa, 2).'%',
+        ];
+
+        $subtitulo = '';
+        if ($filtros->dataInicio !== null && $filtros->dataFim !== null) {
+            $subtitulo = "Período: {$filtros->dataInicio->format('d/m/Y')} a {$filtros->dataFim->format('d/m/Y')}";
+        }
+
+        return new DadosRelatorio(
+            tipo: TipoRelatorioEnum::OCUPACAO_ESPACOS,
+            titulo: TipoRelatorioEnum::OCUPACAO_ESPACOS->titulo(),
+            subtitulo: $subtitulo,
+            colunas: $colunas,
+            linhas: $linhas,
+            sumario: $sumario,
+            filtrosAplicados: $filtros->resumo(),
+            geradoPor: $usuario->name,
+            geradoEm: CarbonImmutable::now(),
+        );
+    }
+}

--- a/app/Services/Relatorio/Reports/RelatorioInterface.php
+++ b/app/Services/Relatorio/Reports/RelatorioInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Reports;
+
+use App\Models\User;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use App\Services\Relatorio\Data\FiltrosRelatorio;
+
+interface RelatorioInterface
+{
+    public function gerar(User $usuario, FiltrosRelatorio $filtros): DadosRelatorio;
+}

--- a/app/Services/Relatorio/Reports/ReservasPeriodoRelatorio.php
+++ b/app/Services/Relatorio/Reports/ReservasPeriodoRelatorio.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Relatorio\Reports;
 
 use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Enums\SituacaoReserva\SituacaoReservaEnum;
 use App\Models\Reserva;
 use App\Models\User;
 use App\Services\Relatorio\Data\ColunaRelatorio;
@@ -16,7 +17,7 @@ final class ReservasPeriodoRelatorio implements RelatorioInterface
 {
     public function gerar(User $usuario, FiltrosRelatorio $filtros): DadosRelatorio
     {
-        $query = Reserva::query()->with(['user', 'horarios.agenda.espaco']);
+        $query = Reserva::query()->with('user')->withCount('horarios');
 
         if ($filtros->dataInicio !== null || $filtros->dataFim !== null) {
             $query->whereHas('horarios', function ($h) use ($filtros) {
@@ -40,6 +41,10 @@ final class ReservasPeriodoRelatorio implements RelatorioInterface
             });
         }
 
+        if ($filtros->turnos !== null) {
+            $query->whereHas('horarios.agenda', fn ($q) => $q->whereIn('turno', $filtros->turnos));
+        }
+
         if ($filtros->instituicaoId !== null && $filtros->agendaIds === null) {
             $query->whereHas('horarios.agenda.espaco.andar.modulo.unidade', function ($u) use ($filtros) {
                 $u->where('instituicao_id', $filtros->instituicaoId);
@@ -54,9 +59,9 @@ final class ReservasPeriodoRelatorio implements RelatorioInterface
             'solicitante' => $r->user->name ?? '—',
             'data_inicial' => CarbonImmutable::parse($r->data_inicial)->setTimezone('America/Bahia')->format('d/m/Y H:i'),
             'data_final' => CarbonImmutable::parse($r->data_final)->setTimezone('America/Bahia')->format('d/m/Y H:i'),
-            'situacao' => $r->situacao,
+            'situacao' => SituacaoReservaEnum::labelDe($r->situacao),
             'recorrencia' => $r->recorrencia ?? '—',
-            'total_slots' => $r->horarios->count(),
+            'total_slots' => (int) $r->getAttribute('horarios_count'),
         ])->toArray();
 
         $colunas = [

--- a/app/Services/Relatorio/Reports/ReservasPeriodoRelatorio.php
+++ b/app/Services/Relatorio/Reports/ReservasPeriodoRelatorio.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Relatorio\Reports;
+
+use App\Enums\Relatorio\TipoRelatorioEnum;
+use App\Models\Reserva;
+use App\Models\User;
+use App\Services\Relatorio\Data\ColunaRelatorio;
+use App\Services\Relatorio\Data\DadosRelatorio;
+use App\Services\Relatorio\Data\FiltrosRelatorio;
+use Carbon\CarbonImmutable;
+
+final class ReservasPeriodoRelatorio implements RelatorioInterface
+{
+    public function gerar(User $usuario, FiltrosRelatorio $filtros): DadosRelatorio
+    {
+        $query = Reserva::query()->with(['user', 'horarios.agenda.espaco']);
+
+        if ($filtros->dataInicio !== null || $filtros->dataFim !== null) {
+            $query->whereHas('horarios', function ($h) use ($filtros) {
+                if ($filtros->dataInicio !== null && $filtros->dataFim !== null) {
+                    $h->whereBetween('data', [$filtros->dataInicio, $filtros->dataFim]);
+                } elseif ($filtros->dataInicio !== null) {
+                    $h->where('data', '>=', $filtros->dataInicio);
+                } elseif ($filtros->dataFim !== null) {
+                    $h->where('data', '<=', $filtros->dataFim);
+                }
+            });
+        }
+
+        if ($filtros->situacoes !== null) {
+            $query->whereIn('situacao', $filtros->situacoes);
+        }
+
+        if ($filtros->agendaIds !== null) {
+            $query->whereHas('horarios', function ($h) use ($filtros) {
+                $h->whereIn('agenda_id', $filtros->agendaIds);
+            });
+        }
+
+        if ($filtros->instituicaoId !== null && $filtros->agendaIds === null) {
+            $query->whereHas('horarios.agenda.espaco.andar.modulo.unidade', function ($u) use ($filtros) {
+                $u->where('instituicao_id', $filtros->instituicaoId);
+            });
+        }
+
+        $reservas = $query->latest('data_inicial')->get();
+
+        $linhas = $reservas->map(fn (Reserva $r) => [
+            'id' => $r->id,
+            'titulo' => $r->titulo,
+            'solicitante' => $r->user->name ?? '—',
+            'data_inicial' => CarbonImmutable::parse($r->data_inicial)->setTimezone('America/Bahia')->format('d/m/Y H:i'),
+            'data_final' => CarbonImmutable::parse($r->data_final)->setTimezone('America/Bahia')->format('d/m/Y H:i'),
+            'situacao' => $r->situacao,
+            'recorrencia' => $r->recorrencia ?? '—',
+            'total_slots' => $r->horarios->count(),
+        ])->toArray();
+
+        $colunas = [
+            new ColunaRelatorio('id', 'ID', 'integer', 5),
+            new ColunaRelatorio('titulo', 'Título', 'string', 20),
+            new ColunaRelatorio('solicitante', 'Solicitante', 'string', 15),
+            new ColunaRelatorio('data_inicial', 'Data Inicial', 'datetime', 12),
+            new ColunaRelatorio('data_final', 'Data Final', 'datetime', 12),
+            new ColunaRelatorio('situacao', 'Situação', 'string', 12),
+            new ColunaRelatorio('recorrencia', 'Recorrência', 'string', 10),
+            new ColunaRelatorio('total_slots', 'Slots', 'integer', 5),
+        ];
+
+        $sumario = [
+            'Total de Reservas' => count($linhas),
+            'Deferidas' => $reservas->where('situacao', 'deferida')->count(),
+            'Indeferidas' => $reservas->where('situacao', 'indeferida')->count(),
+            'Em Análise' => $reservas->where('situacao', 'em_analise')->count(),
+        ];
+
+        $subtitulo = '';
+        if ($filtros->dataInicio !== null && $filtros->dataFim !== null) {
+            $subtitulo = "Período: {$filtros->dataInicio->format('d/m/Y')} a {$filtros->dataFim->format('d/m/Y')}";
+        }
+
+        return new DadosRelatorio(
+            tipo: TipoRelatorioEnum::RESERVAS_PERIODO,
+            titulo: TipoRelatorioEnum::RESERVAS_PERIODO->titulo(),
+            subtitulo: $subtitulo,
+            colunas: $colunas,
+            linhas: $linhas,
+            sumario: $sumario,
+            filtrosAplicados: $filtros->resumo(),
+            geradoPor: $usuario->name,
+            geradoEm: CarbonImmutable::now(),
+        );
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 use App\Providers\AppServiceProvider;
 use App\Providers\FortifyServiceProvider;
+use App\Providers\RelatorioServiceProvider;
 use App\Providers\TelescopeServiceProvider;
 
 return [
     AppServiceProvider::class,
     FortifyServiceProvider::class,
+    RelatorioServiceProvider::class,
     TelescopeServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,13 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "barryvdh/laravel-dompdf": "^3.1",
         "inertiajs/inertia-laravel": "2.0.2",
         "laravel/fortify": "^1.35",
         "laravel/framework": "12.10.1",
         "laravel/reverb": "^1.7",
         "laravel/tinker": "2.10.1",
+        "maatwebsite/excel": "^3.1",
         "pusher/pusher-php-server": "^7.2",
         "spatie/laravel-permission": "^6.0",
         "tightenco/ziggy": "2.5.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03e2f27a601d95d0c3f5a4bf59295d39",
+    "content-hash": "46d0b21ede8c216f3e8d97cea0d639ce",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -60,6 +60,83 @@
                 "source": "https://github.com/Bacon/BaconQrCode/tree/v3.0.3"
             },
             "time": "2025-11-19T17:15:36+00:00"
+        },
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "ee3b72b19ccdf57d0243116ecb2b90261344dedc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/ee3b72b19ccdf57d0243116ecb2b90261344dedc",
+                "reference": "ee3b72b19ccdf57d0243116ecb2b90261344dedc",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^3.0",
+                "illuminate/support": "^9|^10|^11|^12|^13.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7|^3.0",
+                "orchestra/testbench": "^7|^8|^9.16|^10|^11.0",
+                "phpro/grumphp": "^2.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                        "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    },
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-21T08:51:10+00:00"
         },
         {
             "name": "brick/math",
@@ -319,6 +396,162 @@
                 }
             ],
             "time": "2025-01-03T16:18:33+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "dasprid/enum",
@@ -614,6 +847,161 @@
             "time": "2024-02-05T11:56:58+00:00"
         },
         {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.5"
+            },
+            "time": "2026-03-03T13:54:37+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.2"
+            },
+            "time": "2026-01-20T14:10:26+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4 || ^9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.2"
+            },
+            "time": "2026-01-02T16:01:13+00:00"
+        },
+        {
             "name": "dragonmantank/cron-expression",
             "version": "v3.4.0",
             "source": {
@@ -791,6 +1179,67 @@
                 "source": "https://github.com/igorw/evenement/tree/v3.0.2"
             },
             "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
+            },
+            "suggest": {
+                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
+                "ext-bcmath": "Used for unit conversion and imagecrash protection",
+                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
+                "ext-tidy": "Used for pretty-printing HTML"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
+            },
+            "time": "2025-10-17T16:34:55+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -2499,6 +2948,339 @@
             "time": "2024-12-08T08:18:47+00:00"
         },
         {
+            "name": "maatwebsite/excel",
+            "version": "3.1.69",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SpartnerNL/Laravel-Excel.git",
+                "reference": "ae5d65b7c9a2fac43bff4d44f796ac95d7a8e760"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SpartnerNL/Laravel-Excel/zipball/ae5d65b7c9a2fac43bff4d44f796ac95d7a8e760",
+                "reference": "ae5d65b7c9a2fac43bff4d44f796ac95d7a8e760",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^3.3",
+                "ext-json": "*",
+                "illuminate/support": "5.8.*||^6.0||^7.0||^8.0||^9.0||^10.0||^11.0||^12.0||^13.0",
+                "php": "^7.0||^8.0",
+                "phpoffice/phpspreadsheet": "^1.30.4",
+                "psr/simple-cache": "^1.0||^2.0||^3.0"
+            },
+            "require-dev": {
+                "laravel/scout": "^7.0||^8.0||^9.0||^10.0||^11.0",
+                "orchestra/testbench": "^6.0||^7.0||^8.0||^9.0||^10.0||^11.0",
+                "predis/predis": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Excel": "Maatwebsite\\Excel\\Facades\\Excel"
+                    },
+                    "providers": [
+                        "Maatwebsite\\Excel\\ExcelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Maatwebsite\\Excel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Patrick Brouwers",
+                    "email": "patrick@spartner.nl"
+                }
+            ],
+            "description": "Supercharged Excel exports and imports in Laravel",
+            "keywords": [
+                "PHPExcel",
+                "batch",
+                "csv",
+                "excel",
+                "export",
+                "import",
+                "laravel",
+                "php",
+                "phpspreadsheet"
+            ],
+            "support": {
+                "issues": "https://github.com/SpartnerNL/Laravel-Excel/issues",
+                "source": "https://github.com/SpartnerNL/Laravel-Excel/tree/3.1.69"
+            },
+            "funding": [
+                {
+                    "url": "https://laravel-excel.com/commercial-support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/patrickbrouwers",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-30T20:03:58+00:00"
+        },
+        {
+            "name": "maennchen/zipstream-php",
+            "version": "3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-zlib": "*",
+                "php-64bit": "^8.3"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.7",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.86",
+                "guzzlehttp/guzzle": "^7.5",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpunit/phpunit": "^12.0",
+                "vimeo/psalm": "^6.0"
+            },
+            "suggest": {
+                "guzzlehttp/psr7": "^2.4",
+                "psr/http-message": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "support": {
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/maennchen",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-11T18:38:28+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "reference": "95c56caa1cf5c766ad6d65b6344b807c1e8405b9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Complex\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with complex numbers",
+            "homepage": "https://github.com/MarkBaker/PHPComplex",
+            "keywords": [
+                "complex",
+                "mathematics"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPComplex/issues",
+                "source": "https://github.com/MarkBaker/PHPComplex/tree/3.0.2"
+            },
+            "time": "2022-12-06T16:21:08+00:00"
+        },
+        {
+            "name": "markbaker/matrix",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPMatrix.git",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/728434227fe21be27ff6d86621a1b13107a2562c",
+                "reference": "728434227fe21be27ff6d86621a1b13107a2562c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "^4.0",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matrix\\": "classes/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@demon-angel.eu"
+                }
+            ],
+            "description": "PHP Class for working with matrices",
+            "homepage": "https://github.com/MarkBaker/PHPMatrix",
+            "keywords": [
+                "mathematics",
+                "matrix",
+                "vector"
+            ],
+            "support": {
+                "issues": "https://github.com/MarkBaker/PHPMatrix/issues",
+                "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.1"
+            },
+            "time": "2022-12-02T22:17:43+00:00"
+        },
+        {
+            "name": "masterminds/html5",
+            "version": "2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fd5018f6815fff903946d0564977b44ce8010e29",
+                "reference": "fd5018f6815fff903946d0564977b44ce8010e29",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9 || ^10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.1"
+            },
+            "time": "2026-06-23T18:43:15+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.9.0",
             "source": {
@@ -3159,6 +3941,114 @@
                 "source": "https://github.com/paragonie/sodium_compat/tree/v2.1.0"
             },
             "time": "2024-09-04T12:51:01+00:00"
+        },
+        {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "1.30.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "a416375ffc8bf5b661c1bb4e6c60d8f3fddbe5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/a416375ffc8bf5b661c1bb4e6c60d8f3fddbe5ce",
+                "reference": "a416375ffc8bf5b661c1bb4e6c60d8f3fddbe5ce",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1||^2||^3",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-xml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "ezyang/htmlpurifier": "^4.15",
+                "maennchen/zipstream-php": "^2.1 || ^3.0",
+                "markbaker/complex": "^3.0",
+                "markbaker/matrix": "^3.0",
+                "php": ">=7.4.0 <8.5.0",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "dev-main",
+                "doctrine/instantiator": "^1.5",
+                "dompdf/dompdf": "^1.0 || ^2.0 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "mitoteam/jpgraph": "^10.3",
+                "mpdf/mpdf": "^8.1.1",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.7",
+                "tecnickcom/tcpdf": "^6.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer",
+                "ext-intl": "PHP Internationalization Functions",
+                "mitoteam/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "https://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker",
+                    "homepage": "https://markbakeruk.net"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Adrien Crivelli"
+                },
+                {
+                    "name": "Owen Leibman"
+                }
+            ],
+            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "gnumeric",
+                "ods",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.30.6"
+            },
+            "time": "2026-07-12T19:59:31+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -4639,6 +5529,86 @@
                 }
             ],
             "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v9.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "reference": "fd3bf9fb173e0df649bc4e3e0d088a1b2417c08f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/extension-installer": "1.4.3",
+                "phpstan/phpstan": "1.12.33 || 2.2.2",
+                "phpstan/phpstan-phpunit": "1.4.2 || 2.0.16",
+                "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.11",
+                "phpunit/phpunit": "8.5.52",
+                "rawr/phpunit-data-provider": "3.3.1",
+                "rector/rector": "1.2.10 || 2.4.6",
+                "rector/type-perfect": "1.0.0 || 2.1.3",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "thecodingmachine/phpstan-safe-rule": "1.2.0 || 1.4.3"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.5.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Rule/Rule.php",
+                    "src/RuleSet/RuleContainer.php"
+                ],
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.4.0"
+            },
+            "time": "2026-06-18T15:10:53+00:00"
         },
         {
             "name": "spatie/laravel-permission",
@@ -6951,6 +7921,149 @@
                 }
             ],
             "time": "2025-01-17T11:39:41+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rnp.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/shish",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-04T18:08:13+00:00"
         },
         {
             "name": "tightenco/ziggy",

--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Settings
+    |--------------------------------------------------------------------------
+    |
+    | Set some default values. It is possible to add all defines that can be set
+    | in dompdf_config.inc.php. You can also override the entire config file.
+    |
+    */
+    'show_warnings' => false,   // Throw an Exception on warnings from dompdf
+
+    'public_path' => null,  // Override the public path if needed
+
+    /*
+     * Dejavu Sans font is missing glyphs for converted entities, turn it off if you need to show € and £.
+     */
+    'convert_entities' => true,
+
+    'options' => [
+        /**
+         * The location of the DOMPDF font directory
+         *
+         * The location of the directory where DOMPDF will store fonts and font metrics
+         * Note: This directory must exist and be writable by the webserver process.
+         * *Please note the trailing slash.*
+         *
+         * Notes regarding fonts:
+         * Additional .afm font metrics can be added by executing load_font.php from command line.
+         *
+         * Only the original "Base 14 fonts" are present on all pdf viewers. Additional fonts must
+         * be embedded in the pdf file or the PDF may not display correctly. This can significantly
+         * increase file size unless font subsetting is enabled. Before embedding a font please
+         * review your rights under the font license.
+         *
+         * Any font specification in the source HTML is translated to the closest font available
+         * in the font directory.
+         *
+         * The pdf standard "Base 14 fonts" are:
+         * Courier, Courier-Bold, Courier-BoldOblique, Courier-Oblique,
+         * Helvetica, Helvetica-Bold, Helvetica-BoldOblique, Helvetica-Oblique,
+         * Times-Roman, Times-Bold, Times-BoldItalic, Times-Italic,
+         * Symbol, ZapfDingbats.
+         */
+        'font_dir' => storage_path('fonts'), // advised by dompdf (https://github.com/dompdf/dompdf/pull/782)
+
+        /**
+         * The location of the DOMPDF font cache directory
+         *
+         * This directory contains the cached font metrics for the fonts used by DOMPDF.
+         * This directory can be the same as DOMPDF_FONT_DIR
+         *
+         * Note: This directory must exist and be writable by the webserver process.
+         */
+        'font_cache' => storage_path('fonts'),
+
+        /**
+         * The location of a temporary directory.
+         *
+         * The directory specified must be writeable by the webserver process.
+         * The temporary directory is required to download remote images and when
+         * using the PDFLib back end.
+         */
+        'temp_dir' => sys_get_temp_dir(),
+
+        /**
+         * ==== IMPORTANT ====
+         *
+         * dompdf's "chroot": Prevents dompdf from accessing system files or other
+         * files on the webserver.  All local files opened by dompdf must be in a
+         * subdirectory of this directory.  DO NOT set it to '/' since this could
+         * allow an attacker to use dompdf to read any files on the server.  This
+         * should be an absolute path.
+         * This is only checked on command line call by dompdf.php, but not by
+         * direct class use like:
+         * $dompdf = new DOMPDF();  $dompdf->load_html($htmldata); $dompdf->render(); $pdfdata = $dompdf->output();
+         */
+        'chroot' => public_path(),
+
+        /**
+         * Protocol whitelist
+         *
+         * Protocols and PHP wrappers allowed in URIs, and the validation rules
+         * that determine if a resouce may be loaded. Full support is not guaranteed
+         * for the protocols/wrappers specified
+         * by this array.
+         *
+         * @var array
+         */
+        'allowed_protocols' => [
+            'data://' => ['rules' => []],
+            'file://' => ['rules' => []],
+            'http://' => ['rules' => []],
+            'https://' => ['rules' => []],
+        ],
+
+        /**
+         * Operational artifact (log files, temporary files) path validation
+         */
+        'artifactPathValidation' => null,
+
+        /**
+         * @var string
+         */
+        'log_output_file' => null,
+
+        /**
+         * Whether to enable font subsetting or not.
+         */
+        'enable_font_subsetting' => false,
+
+        /**
+         * The PDF rendering backend to use
+         *
+         * Valid settings are 'PDFLib', 'CPDF' (the bundled R&OS PDF class), 'GD' and
+         * 'auto'. 'auto' will look for PDFLib and use it if found, or if not it will
+         * fall back on CPDF. 'GD' renders PDFs to graphic files.
+         * {@link * Canvas_Factory} ultimately determines which rendering class to
+         * instantiate based on this setting.
+         *
+         * Both PDFLib & CPDF rendering backends provide sufficient rendering
+         * capabilities for dompdf, however additional features (e.g. object,
+         * image and font support, etc.) differ between backends.  Please see
+         * {@link PDFLib_Adapter} for more information on the PDFLib backend
+         * and {@link CPDF_Adapter} and lib/class.pdf.php for more information
+         * on CPDF. Also see the documentation for each backend at the links
+         * below.
+         *
+         * The GD rendering backend is a little different than PDFLib and
+         * CPDF. Several features of CPDF and PDFLib are not supported or do
+         * not make any sense when creating image files.  For example,
+         * multiple pages are not supported, nor are PDF 'objects'.  Have a
+         * look at {@link GD_Adapter} for more information.  GD support is
+         * experimental, so use it at your own risk.
+         *
+         * @link http://www.pdflib.com
+         * @link http://www.ros.co.nz/pdf
+         * @link http://www.php.net/image
+         */
+        'pdf_backend' => 'CPDF',
+
+        /**
+         * html target media view which should be rendered into pdf.
+         * List of types and parsing rules for future extensions:
+         * http://www.w3.org/TR/REC-html40/types.html
+         *   screen, tty, tv, projection, handheld, print, braille, aural, all
+         * Note: aural is deprecated in CSS 2.1 because it is replaced by speech in CSS 3.
+         * Note, even though the generated pdf file is intended for print output,
+         * the desired content might be different (e.g. screen or projection view of html file).
+         * Therefore allow specification of content here.
+         */
+        'default_media_type' => 'screen',
+
+        /**
+         * The default paper size.
+         *
+         * North America standard is "letter"; other countries generally "a4"
+         *
+         * @see CPDF_Adapter::PAPER_SIZES for valid sizes ('letter', 'legal', 'A4', etc.)
+         */
+        'default_paper_size' => 'a4',
+
+        /**
+         * The default paper orientation.
+         *
+         * The orientation of the page (portrait or landscape).
+         *
+         * @var string
+         */
+        'default_paper_orientation' => 'portrait',
+
+        /**
+         * The default font family
+         *
+         * Used if no suitable fonts can be found. This must exist in the font folder.
+         *
+         * @var string
+         */
+        'default_font' => 'DejaVu Sans',
+
+        /**
+         * Image DPI setting
+         *
+         * This setting determines the default DPI setting for images and fonts.  The
+         * DPI may be overridden for inline images by explictly setting the
+         * image's width & height style attributes (i.e. if the image's native
+         * width is 600 pixels and you specify the image's width as 72 points,
+         * the image will have a DPI of 600 in the rendered PDF.  The DPI of
+         * background images can not be overridden and is controlled entirely
+         * via this parameter.
+         *
+         * For the purposes of DOMPDF, pixels per inch (PPI) = dots per inch (DPI).
+         * If a size in html is given as px (or without unit as image size),
+         * this tells the corresponding size in pt.
+         * This adjusts the relative sizes to be similar to the rendering of the
+         * html page in a reference browser.
+         *
+         * In pdf, always 1 pt = 1/72 inch
+         *
+         * Rendering resolution of various browsers in px per inch:
+         * Windows Firefox and Internet Explorer:
+         *   SystemControl->Display properties->FontResolution: Default:96, largefonts:120, custom:?
+         * Linux Firefox:
+         *   about:config *resolution: Default:96
+         *   (xorg screen dimension in mm and Desktop font dpi settings are ignored)
+         *
+         * Take care about extra font/image zoom factor of browser.
+         *
+         * In images, <img> size in pixel attribute, img css style, are overriding
+         * the real image dimension in px for rendering.
+         *
+         * @var int
+         */
+        'dpi' => 96,
+
+        /**
+         * Enable embedded PHP
+         *
+         * If this setting is set to true then DOMPDF will automatically evaluate embedded PHP contained
+         * within <script type="text/php"> ... </script> tags.
+         *
+         * ==== IMPORTANT ==== Enabling this for documents you do not trust (e.g. arbitrary remote html pages)
+         * is a security risk.
+         * Embedded scripts are run with the same level of system access available to dompdf.
+         * Set this option to false (recommended) if you wish to process untrusted documents.
+         * This setting may increase the risk of system exploit.
+         * Do not change this settings without understanding the consequences.
+         * Additional documentation is available on the dompdf wiki at:
+         * https://github.com/dompdf/dompdf/wiki
+         *
+         * @var bool
+         */
+        'enable_php' => false,
+
+        /**
+         * Enable inline JavaScript
+         *
+         * If this setting is set to true then DOMPDF will automatically insert JavaScript code contained
+         * within <script type="text/javascript"> ... </script> tags as written into the PDF.
+         * NOTE: This is PDF-based JavaScript to be executed by the PDF viewer,
+         * not browser-based JavaScript executed by Dompdf.
+         *
+         * @var bool
+         */
+        'enable_javascript' => true,
+
+        /**
+         * Enable remote file access
+         *
+         *  If this setting is set to true, DOMPDF will access remote sites for
+         *  images and CSS files as required.
+         *
+         *  ==== IMPORTANT ====
+         *  This can be a security risk, in particular in combination with isPhpEnabled and
+         *  allowing remote html code to be passed to $dompdf = new DOMPDF(); $dompdf->load_html(...);
+         *  This allows anonymous users to download legally doubtful internet content which on
+         *  tracing back appears to being downloaded by your server, or allows malicious php code
+         *  in remote html pages to be executed by your server with your account privileges.
+         *
+         *  This setting may increase the risk of system exploit. Do not change
+         *  this settings without understanding the consequences. Additional
+         *  documentation is available on the dompdf wiki at:
+         *  https://github.com/dompdf/dompdf/wiki
+         *
+         * @var bool
+         */
+        'enable_remote' => false,
+
+        /**
+         * List of allowed remote hosts
+         *
+         * Each value of the array must be a valid hostname.
+         *
+         * This will be used to filter which resources can be loaded in combination with
+         * isRemoteEnabled. If enable_remote is FALSE, then this will have no effect.
+         *
+         * Leave to NULL to allow any remote host.
+         *
+         * @var array|null
+         */
+        'allowed_remote_hosts' => null,
+
+        /**
+         * A ratio applied to the fonts height to be more like browsers' line height
+         */
+        'font_height_ratio' => 1.1,
+
+        /**
+         * Use the HTML5 Lib parser
+         *
+         * @deprecated This feature is now always on in dompdf 2.x
+         *
+         * @var bool
+         */
+        'enable_html5_parser' => true,
+    ],
+
+];

--- a/config/excel.php
+++ b/config/excel.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+use Maatwebsite\Excel\DefaultValueBinder;
+use Maatwebsite\Excel\Excel;
+use PhpOffice\PhpSpreadsheet\Reader\Csv;
+
+return [
+    'exports' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Chunk size
+        |--------------------------------------------------------------------------
+        |
+        | When using FromQuery, the query is automatically chunked.
+        | Here you can specify how big the chunk should be.
+        |
+        */
+        'chunk_size' => 1000,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Pre-calculate formulas during export
+        |--------------------------------------------------------------------------
+        */
+        'pre_calculate_formulas' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Enable strict null comparison
+        |--------------------------------------------------------------------------
+        |
+        | When enabling strict null comparison empty cells ('') will
+        | be added to the sheet.
+        */
+        'strict_null_comparison' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | CSV Settings
+        |--------------------------------------------------------------------------
+        |
+        | Configure e.g. delimiter, enclosure and line ending for CSV exports.
+        |
+        */
+        'csv' => [
+            'delimiter' => ';',
+            'enclosure' => '"',
+            'line_ending' => "\n",
+            'use_bom' => true,
+            'include_separator_line' => false,
+            'excel_compatibility' => false,
+            'output_encoding' => '',
+            'test_auto_detect' => true,
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Worksheet properties
+        |--------------------------------------------------------------------------
+        |
+        | Configure e.g. default title, creator, subject,...
+        |
+        */
+        'properties' => [
+            'creator' => '',
+            'lastModifiedBy' => '',
+            'title' => '',
+            'description' => '',
+            'subject' => '',
+            'keywords' => '',
+            'category' => '',
+            'manager' => '',
+            'company' => '',
+        ],
+    ],
+
+    'imports' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Read Only
+        |--------------------------------------------------------------------------
+        |
+        | When dealing with imports, you might only be interested in the
+        | data that the sheet exists. By default we ignore all styles,
+        | however if you want to do some logic based on style data
+        | you can enable it by setting read_only to false.
+        |
+        */
+        'read_only' => true,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Ignore Empty
+        |--------------------------------------------------------------------------
+        |
+        | When dealing with imports, you might be interested in ignoring
+        | rows that have null values or empty strings. By default rows
+        | containing empty strings or empty values are not ignored but can be
+        | ignored by enabling the setting ignore_empty to true.
+        |
+        */
+        'ignore_empty' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Heading Row Formatter
+        |--------------------------------------------------------------------------
+        |
+        | Configure the heading row formatter.
+        | Available options: none|slug|custom
+        |
+        */
+        'heading_row' => [
+            'formatter' => 'slug',
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | CSV Settings
+        |--------------------------------------------------------------------------
+        |
+        | Configure e.g. delimiter, enclosure and line ending for CSV imports.
+        |
+        */
+        'csv' => [
+            'delimiter' => null,
+            'enclosure' => '"',
+            'escape_character' => '\\',
+            'contiguous' => false,
+            'input_encoding' => Csv::GUESS_ENCODING,
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Worksheet properties
+        |--------------------------------------------------------------------------
+        |
+        | Configure e.g. default title, creator, subject,...
+        |
+        */
+        'properties' => [
+            'creator' => '',
+            'lastModifiedBy' => '',
+            'title' => '',
+            'description' => '',
+            'subject' => '',
+            'keywords' => '',
+            'category' => '',
+            'manager' => '',
+            'company' => '',
+        ],
+
+        /*
+       |--------------------------------------------------------------------------
+       | Cell Middleware
+       |--------------------------------------------------------------------------
+       |
+       | Configure middleware that is executed on getting a cell value
+       |
+       */
+        'cells' => [
+            'middleware' => [
+                // \Maatwebsite\Excel\Middleware\TrimCellValue::class,
+                // \Maatwebsite\Excel\Middleware\ConvertEmptyCellValuesToNull::class,
+            ],
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Extension detector
+    |--------------------------------------------------------------------------
+    |
+    | Configure here which writer/reader type should be used when the package
+    | needs to guess the correct type based on the extension alone.
+    |
+    */
+    'extension_detector' => [
+        'xlsx' => Excel::XLSX,
+        'xlsm' => Excel::XLSX,
+        'xltx' => Excel::XLSX,
+        'xltm' => Excel::XLSX,
+        'xls' => Excel::XLS,
+        'xlt' => Excel::XLS,
+        'ods' => Excel::ODS,
+        'ots' => Excel::ODS,
+        'slk' => Excel::SLK,
+        'xml' => Excel::XML,
+        'gnumeric' => Excel::GNUMERIC,
+        'htm' => Excel::HTML,
+        'html' => Excel::HTML,
+        'csv' => Excel::CSV,
+        'tsv' => Excel::TSV,
+
+        /*
+        |--------------------------------------------------------------------------
+        | PDF Extension
+        |--------------------------------------------------------------------------
+        |
+        | Configure here which Pdf driver should be used by default.
+        | Available options: Excel::MPDF | Excel::TCPDF | Excel::DOMPDF
+        |
+        */
+        'pdf' => Excel::DOMPDF,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Value Binder
+    |--------------------------------------------------------------------------
+    |
+    | PhpSpreadsheet offers a way to hook into the process of a value being
+    | written to a cell. In there some assumptions are made on how the
+    | value should be formatted. If you want to change those defaults,
+    | you can implement your own default value binder.
+    |
+    | Possible value binders:
+    |
+    | [x] Maatwebsite\Excel\DefaultValueBinder::class
+    | [x] PhpOffice\PhpSpreadsheet\Cell\StringValueBinder::class
+    | [x] PhpOffice\PhpSpreadsheet\Cell\AdvancedValueBinder::class
+    |
+    */
+    'value_binder' => [
+        'default' => DefaultValueBinder::class,
+    ],
+
+    'cache' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Default cell caching driver
+        |--------------------------------------------------------------------------
+        |
+        | By default PhpSpreadsheet keeps all cell values in memory, however when
+        | dealing with large files, this might result into memory issues. If you
+        | want to mitigate that, you can configure a cell caching driver here.
+        | When using the illuminate driver, it will store each value in the
+        | cache store. This can slow down the process, because it needs to
+        | store each value. You can use the "batch" store if you want to
+        | only persist to the store when the memory limit is reached.
+        |
+        | Drivers: memory|illuminate|batch
+        |
+        */
+        'driver' => 'memory',
+
+        /*
+        |--------------------------------------------------------------------------
+        | Batch memory caching
+        |--------------------------------------------------------------------------
+        |
+        | When dealing with the "batch" caching driver, it will only
+        | persist to the store when the memory limit is reached.
+        | Here you can tweak the memory limit to your liking.
+        |
+        */
+        'batch' => [
+            'memory_limit' => 60000,
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Illuminate cache
+        |--------------------------------------------------------------------------
+        |
+        | When using the "illuminate" caching driver, it will automatically use
+        | your default cache store. However if you prefer to have the cell
+        | cache on a separate store, you can configure the store name here.
+        | You can use any store defined in your cache config. When leaving
+        | at "null" it will use the default store.
+        |
+        */
+        'illuminate' => [
+            'store' => null,
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Cache Time-to-live (TTL)
+        |--------------------------------------------------------------------------
+        |
+        | The TTL of items written to cache. If you want to keep the items cached
+        | indefinitely, set this to null.  Otherwise, set a number of seconds,
+        | a \DateInterval, or a callable.
+        |
+        | Allowable types: callable|\DateInterval|int|null
+        |
+         */
+        'default_ttl' => 10800,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Transaction Handler
+    |--------------------------------------------------------------------------
+    |
+    | By default the import is wrapped in a transaction. This is useful
+    | for when an import may fail and you want to retry it. With the
+    | transactions, the previous import gets rolled-back.
+    |
+    | You can disable the transaction handler by setting this to null.
+    | Or you can choose a custom made transaction handler here.
+    |
+    | Supported handlers: null|db
+    |
+    */
+    'transactions' => [
+        'handler' => 'db',
+        'db' => [
+            'connection' => null,
+        ],
+    ],
+
+    'temporary_files' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Local Temporary Path
+        |--------------------------------------------------------------------------
+        |
+        | When exporting and importing files, we use a temporary file, before
+        | storing reading or downloading. Here you can customize that path.
+        | permissions is an array with the permission flags for the directory (dir)
+        | and the create file (file).
+        |
+        */
+        'local_path' => storage_path('framework/cache/laravel-excel'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Local Temporary Path Permissions
+        |--------------------------------------------------------------------------
+        |
+        | Permissions is an array with the permission flags for the directory (dir)
+        | and the create file (file).
+        | If omitted the default permissions of the filesystem will be used.
+        |
+        */
+        'local_permissions' => [
+            // 'dir'  => 0755,
+            // 'file' => 0644,
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Remote Temporary Disk
+        |--------------------------------------------------------------------------
+        |
+        | When dealing with a multi server setup with queues in which you
+        | cannot rely on having a shared local temporary path, you might
+        | want to store the temporary file on a shared disk. During the
+        | queue executing, we'll retrieve the temporary file from that
+        | location instead. When left to null, it will always use
+        | the local path. This setting only has effect when using
+        | in conjunction with queued imports and exports.
+        |
+        */
+        'remote_disk' => null,
+        'remote_prefix' => null,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Force Resync
+        |--------------------------------------------------------------------------
+        |
+        | When dealing with a multi server setup as above, it's possible
+        | for the clean up that occurs after entire queue has been run to only
+        | cleanup the server that the last AfterImportJob runs on. The rest of the server
+        | would still have the local temporary file stored on it. In this case your
+        | local storage limits can be exceeded and future imports won't be processed.
+        | To mitigate this you can set this config value to be true, so that after every
+        | queued chunk is processed the local temporary file is deleted on the server that
+        | processed it.
+        |
+        */
+        'force_resync_remote' => null,
+    ],
+];

--- a/config/relatorios.php
+++ b/config/relatorios.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+use App\Services\Relatorio\Reports\IndicadoresConsolidadosRelatorio;
+use App\Services\Relatorio\Reports\InventarioEspacosRelatorio;
+use App\Services\Relatorio\Reports\OcupacaoEspacosRelatorio;
+use App\Services\Relatorio\Reports\ReservasPeriodoRelatorio;
+
+return [
+    'tipos' => [
+        'reservas_periodo' => ReservasPeriodoRelatorio::class,
+        'ocupacao_espacos' => OcupacaoEspacosRelatorio::class,
+        'inventario_espacos' => InventarioEspacosRelatorio::class,
+        'indicadores_consolidados' => IndicadoresConsolidadosRelatorio::class,
+    ],
+    'limites' => [
+        'max_linhas_csv_xlsx' => 10_000,
+        'max_linhas_pdf' => 1_500,
+    ],
+    'pdf' => [
+        'orientacao_padrao' => 'portrait',
+        'tamanho' => 'A4',
+        'cor_primaria' => '#1a1a1a',
+    ],
+    'csv' => [
+        'delimiter' => ';',
+        'use_bom' => true,
+    ],
+];

--- a/config/relatorios.php
+++ b/config/relatorios.php
@@ -26,4 +26,9 @@ return [
         'delimiter' => ';',
         'use_bom' => true,
     ],
+    'slots_por_turno' => [
+        'manha' => 6,
+        'tarde' => 6,
+        'noite' => 5,
+    ],
 ];

--- a/database/migrations/2026_04_16_193547_seed_spatie_roles_and_permissions.php
+++ b/database/migrations/2026_04_16_193547_seed_spatie_roles_and_permissions.php
@@ -23,6 +23,7 @@ return new class extends Migration
         'setores.listar', 'setores.visualizar', 'setores.criar', 'setores.atualizar', 'setores.deletar',
         'andares.criar', 'andares.atualizar',
         'sistema.telescope',
+        'relatorios.reservas-periodo', 'relatorios.ocupacao-espacos', 'relatorios.inventario-espacos', 'relatorios.indicadores-consolidados',
     ];
 
     public function up(): void
@@ -38,7 +39,7 @@ return new class extends Migration
         $comum = Role::firstOrCreate(['name' => 'comum',         'guard_name' => 'web'], ['is_system' => true]);
 
         $institucional->syncPermissions(Permission::all());
-        $gestor->syncPermissions(['usuarios.listar', 'usuarios.visualizar', 'reservas.avaliar']);
+        $gestor->syncPermissions(['usuarios.listar', 'usuarios.visualizar', 'reservas.avaliar', 'relatorios.reservas-periodo', 'relatorios.ocupacao-espacos', 'relatorios.inventario-espacos']);
 
         User::where('permission_type_id', 1)->each(fn ($u) => $u->assignRole('institucional'));
         User::where('permission_type_id', 2)->each(fn ($u) => $u->assignRole('gestor'));

--- a/database/migrations/2026_04_17_084219_add_section_permissions.php
+++ b/database/migrations/2026_04_17_084219_add_section_permissions.php
@@ -20,6 +20,7 @@ return new class extends Migration
         'secao.gestao-modulos',
         'secao.gestao-setores',
         'secao.gestao-roles',
+        'secao.relatorios',
     ];
 
     public function up(): void
@@ -38,6 +39,7 @@ return new class extends Migration
         $gestor->givePermissionTo([
             'secao.dashboard-gestor',
             'secao.gestao-reservas',
+            'secao.relatorios',
         ]);
 
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
@@ -51,7 +53,7 @@ return new class extends Migration
         $gestor = Role::findByName('gestor', 'web');
 
         $institucional->revokePermissionTo(self::SECTION_PERMISSIONS);
-        $gestor->revokePermissionTo(['secao.dashboard-gestor', 'secao.gestao-reservas']);
+        $gestor->revokePermissionTo(['secao.dashboard-gestor', 'secao.gestao-reservas', 'secao.relatorios']);
 
         Permission::whereIn('name', self::SECTION_PERMISSIONS)->delete();
 

--- a/database/seeders/Production/PermissionSeeder.php
+++ b/database/seeders/Production/PermissionSeeder.php
@@ -68,6 +68,11 @@ class PermissionSeeder extends Seeder
         'andares.atualizar',
         // Sistema
         'sistema.telescope',
+        // Relatórios
+        'relatorios.reservas-periodo',
+        'relatorios.ocupacao-espacos',
+        'relatorios.inventario-espacos',
+        'relatorios.indicadores-consolidados',
         // Seções (UI access control)
         'secao.dashboard-institucional',
         'secao.dashboard-gestor',
@@ -79,6 +84,7 @@ class PermissionSeeder extends Seeder
         'secao.gestao-modulos',
         'secao.gestao-setores',
         'secao.gestao-roles',
+        'secao.relatorios',
     ];
 
     public function run(): void

--- a/database/seeders/Production/RoleSeeder.php
+++ b/database/seeders/Production/RoleSeeder.php
@@ -40,6 +40,10 @@ class RoleSeeder extends Seeder
             'reservas.avaliar',
             'secao.dashboard-gestor',
             'secao.gestao-reservas',
+            'relatorios.reservas-periodo',
+            'relatorios.ocupacao-espacos',
+            'relatorios.inventario-espacos',
+            'secao.relatorios',
         ]);
     }
 }

--- a/docker/development/php-fpm/Dockerfile
+++ b/docker/development/php-fpm/Dockerfile
@@ -11,9 +11,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl4-openssl-dev \
     libicu-dev \
     libzip-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libfreetype6-dev \
+    libwebp-dev \
     libfcgi-bin \
     procps \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) \
+    gd \
     pdo_mysql \
     pdo_pgsql \
     pgsql \

--- a/docker/development/workspace/Dockerfile
+++ b/docker/development/workspace/Dockerfile
@@ -18,7 +18,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl4-openssl-dev \
     libicu-dev \
     libzip-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libfreetype6-dev \
+    libwebp-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) \
+    gd \
     pdo_mysql \
     pdo_pgsql \
     pgsql \

--- a/docker/production/php-fpm/Dockerfile
+++ b/docker/production/php-fpm/Dockerfile
@@ -44,7 +44,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl4-openssl-dev \
     libicu-dev \
     libzip-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libfreetype6-dev \
+    libwebp-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) \
+    gd \
     pdo_mysql \
     pdo_pgsql \
     pgsql \
@@ -84,6 +90,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     libicu-dev \
     libzip-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libfreetype6-dev \
+    libwebp-dev \
     libfcgi-bin \
     procps \
     && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "uniespacos",
+    "name": "www",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -45,6 +45,8 @@
                 "react-day-picker": "^8.10.1",
                 "react-dom": "^18.3.1",
                 "react-hook-form": "^7.56.4",
+                "react-is": "^18.3.1",
+                "recharts": "^3.10.0",
                 "sonner": "^2.0.5",
                 "tailwind-merge": "3.2.0",
                 "tailwindcss": "4.1.4",
@@ -5586,6 +5588,31 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+            "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.60.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -5921,6 +5948,11 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
         },
         "node_modules/@standard-schema/utils": {
             "version": "0.3.0",
@@ -6419,6 +6451,60 @@
                 "@babel/types": "^7.28.2"
             }
         },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -6530,6 +6616,11 @@
             "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
         },
         "node_modules/@types/yargs": {
             "version": "17.0.35",
@@ -7982,6 +8073,116 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "license": "MIT"
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/data-urls": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -8083,6 +8284,11 @@
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
         },
         "node_modules/dedent": {
             "version": "1.7.1",
@@ -8867,6 +9073,11 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
+        },
         "node_modules/execa": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -9598,6 +9809,15 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "11.1.15",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+            "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9687,6 +9907,14 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/is-array-buffer": {
@@ -12309,13 +12537,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/pretty-format/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -12327,6 +12548,12 @@
                 "object-assign": "^4.1.1",
                 "react-is": "^16.13.1"
             }
+        },
+        "node_modules/prop-types/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true
         },
         "node_modules/proxy-from-env": {
             "version": "2.1.0",
@@ -12463,11 +12690,31 @@
             }
         },
         "node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true,
-            "license": "MIT"
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+        },
+        "node_modules/react-redux": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+            "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/react-refresh": {
             "version": "0.17.0",
@@ -12547,6 +12794,35 @@
                 }
             }
         },
+        "node_modules/recharts": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.0.tgz",
+            "integrity": "sha512-wulMvfncpIlmu2uFtRU/mE5/+NiVtASXkw2KdwJTdHs3WsASX0WxZlX+rpKgyn5BDbIhkPtCpUKkB9XNK5KE0w==",
+            "workspaces": [
+                "www"
+            ],
+            "dependencies": {
+                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^11.1.8",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.2.0",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/redent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12559,6 +12835,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -12671,6 +12960,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/reselect": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+            "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="
         },
         "node_modules/resolve": {
             "version": "2.0.0-next.5",
@@ -13577,6 +13871,11 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.14",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -14223,6 +14522,27 @@
             },
             "engines": {
                 "node": ">=10.12.0"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.56.4",
+        "react-is": "^18.3.1",
+        "recharts": "^3.10.0",
         "sonner": "^2.0.5",
         "tailwind-merge": "3.2.0",
         "tailwindcss": "4.1.4",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
 >
     <testsuites>
@@ -23,10 +23,13 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="pgsql"/>
-        <env name="DB_DATABASE" value="uniespacos"/>
-        <env name="DB_USERNAME" value="uniespacos"/>
-        <env name="DB_PASSWORD" value="uniespacossecretkey"/>
+        <!-- force="true" e obrigatorio: o container ja define DB_* no ambiente
+             e, sem ele, o PHPUnit mantem o valor existente e a suite roda
+             (e apaga, via RefreshDatabase) o banco de desenvolvimento. -->
+        <env name="DB_CONNECTION" value="pgsql" force="true"/>
+        <env name="DB_DATABASE" value="uniespacos_test" force="true"/>
+        <env name="DB_USERNAME" value="uniespacos" force="true"/>
+        <env name="DB_PASSWORD" value="uniespacossecretkey" force="true"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -1,0 +1,382 @@
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"]
+}) {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+type ChartTooltipPayloadItem = {
+  name?: string
+  value?: number | string
+  dataKey?: string | number
+  color?: string
+  payload?: Record<string, unknown> & { fill?: string }
+}
+
+type ChartTooltipContentProps = React.ComponentProps<"div"> & {
+  active?: boolean
+  payload?: ChartTooltipPayloadItem[]
+  label?: unknown
+  labelFormatter?: (value: unknown, payload: ChartTooltipPayloadItem[]) => React.ReactNode
+  labelClassName?: string
+  formatter?: (
+    value: unknown,
+    name: unknown,
+    item: ChartTooltipPayloadItem,
+    index: number,
+    payload: unknown
+  ) => React.ReactNode
+  color?: string
+  hideLabel?: boolean
+  hideIndicator?: boolean
+  indicator?: "line" | "dot" | "dashed"
+  nameKey?: string
+  labelKey?: string
+}
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: ChartTooltipContentProps) {
+  const { config } = useChart()
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null
+    }
+
+    const [item] = payload
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`
+    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      )
+    }
+
+    if (!value) {
+      return null
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ])
+
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot"
+
+  return (
+    <div
+      className={cn(
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+          const indicatorColor = color || item.payload?.fill || item.color
+
+          return (
+            <div
+              key={item.dataKey}
+              className={cn(
+                "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
+                indicator === "dot" && "items-center"
+              )}
+            >
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(item.value, item.name, item, index, item.payload)
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn(
+                          "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                          {
+                            "h-2.5 w-2.5": indicator === "dot",
+                            "w-1": indicator === "line",
+                            "w-0 border-[1.5px] border-dashed bg-transparent":
+                              indicator === "dashed",
+                            "my-0.5": nestLabel && indicator === "dashed",
+                          }
+                        )}
+                        style={
+                          {
+                            "--color-bg": indicatorColor,
+                            "--color-border": indicatorColor,
+                          } as React.CSSProperties
+                        }
+                      />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-1 justify-between leading-none",
+                      nestLabel ? "items-end" : "items-center"
+                    )}
+                  >
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">
+                        {itemConfig?.label || item.name}
+                      </span>
+                    </div>
+                    {item.value && (
+                      <span className="text-foreground font-mono font-medium tabular-nums">
+                        {item.value.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+const ChartLegend = RechartsPrimitive.Legend
+
+type ChartLegendPayloadItem = {
+  value?: string
+  dataKey?: string | number
+  color?: string
+}
+
+type ChartLegendContentProps = React.ComponentProps<"div"> & {
+  payload?: ChartLegendPayloadItem[]
+  verticalAlign?: "top" | "bottom"
+  hideIcon?: boolean
+  nameKey?: string
+}
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: ChartLegendContentProps) {
+  const { config } = useChart()
+
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`
+        const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+        return (
+          <div
+            key={item.value}
+            className={cn(
+              "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
+            )}
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: item.color,
+                }}
+              />
+            )}
+            {itemConfig?.label}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/resources/js/constants/permissions.ts
+++ b/resources/js/constants/permissions.ts
@@ -70,6 +70,12 @@ export const PERMISSION_ANDARES_ATUALIZAR = 'andares.atualizar';
 // Sistema
 export const PERMISSION_SISTEMA_TELESCOPE = 'sistema.telescope';
 
+// Relatórios
+export const PERMISSION_RELATORIOS_RESERVAS_PERIODO = 'relatorios.reservas-periodo';
+export const PERMISSION_RELATORIOS_OCUPACAO_ESPACOS = 'relatorios.ocupacao-espacos';
+export const PERMISSION_RELATORIOS_INVENTARIO_ESPACOS = 'relatorios.inventario-espacos';
+export const PERMISSION_RELATORIOS_INDICADORES_CONSOLIDADOS = 'relatorios.indicadores-consolidados';
+
 // Seções
 export const PERMISSION_SECAO_DASHBOARD_INSTITUCIONAL = 'secao.dashboard-institucional';
 export const PERMISSION_SECAO_DASHBOARD_GESTOR = 'secao.dashboard-gestor';
@@ -81,3 +87,4 @@ export const PERMISSION_SECAO_GESTAO_UNIDADES = 'secao.gestao-unidades';
 export const PERMISSION_SECAO_GESTAO_MODULOS = 'secao.gestao-modulos';
 export const PERMISSION_SECAO_GESTAO_SETORES = 'secao.gestao-setores';
 export const PERMISSION_SECAO_GESTAO_ROLES = 'secao.gestao-roles';
+export const PERMISSION_SECAO_RELATORIOS = 'secao.relatorios';

--- a/resources/js/hooks/use-dados-relatorio.ts
+++ b/resources/js/hooks/use-dados-relatorio.ts
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { DadosRelatorio, FiltrosRelatorio, TipoRelatorio } from '@/types';
+
+export type StatusDadosRelatorio = 'idle' | 'loading' | 'success' | 'error' | 'empty';
+
+const DEBOUNCE_MS = 350;
+
+export function useDadosRelatorio(
+    endpoint: string,
+    tipo: TipoRelatorio | undefined,
+    filtros: FiltrosRelatorio | undefined
+) {
+    const [dados, setDados] = useState<DadosRelatorio | null>(null);
+    const [status, setStatus] = useState<StatusDadosRelatorio>('idle');
+    const [erro, setErro] = useState<string | null>(null);
+
+    const filtrosSerializados = JSON.stringify(filtros ?? {});
+
+    useEffect(() => {
+        // Pula o disparo enquanto nao houver um tipo selecionado (mount sem filtros minimos).
+        if (!tipo) {
+            setStatus('idle');
+            setDados(null);
+            setErro(null);
+            return;
+        }
+
+        const controller = new AbortController();
+
+        const buscar = async (signal: AbortSignal) => {
+            setStatus('loading');
+            setErro(null);
+
+            const metaToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+            const xsrfCookie = decodeURIComponent(
+                document.cookie
+                    .split('; ')
+                    .find((r) => r.startsWith('XSRF-TOKEN='))
+                    ?.split('=')[1] ?? ''
+            );
+
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+                Accept: 'application/json',
+            };
+
+            // Prioriza o cookie XSRF-TOKEN (renovado pelo Laravel a cada resposta) sobre a
+            // meta tag, que fica desatualizada apos o login numa SPA Inertia (sem reload).
+            if (xsrfCookie) {
+                headers['X-XSRF-TOKEN'] = xsrfCookie;
+            } else if (metaToken) {
+                headers['X-CSRF-TOKEN'] = metaToken;
+            }
+
+            try {
+                const response = await fetch(endpoint, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers,
+                    body: JSON.stringify({ tipo, ...filtros }),
+                    signal,
+                });
+
+                if (!response.ok) {
+                    setStatus('error');
+                    setErro('Erro ao carregar dados do relatório.');
+                    return;
+                }
+
+                const json: DadosRelatorio = await response.json();
+
+                setDados(json);
+                setStatus(json.linhas.length === 0 ? 'empty' : 'success');
+            } catch {
+                // Ignora respostas obsoletas de requisicoes canceladas pelo cleanup.
+                if (signal.aborted) {
+                    return;
+                }
+
+                setStatus('error');
+                setErro('Erro ao carregar dados do relatório.');
+            }
+        };
+
+        const timer = setTimeout(() => {
+            void buscar(controller.signal);
+        }, DEBOUNCE_MS);
+
+        return () => {
+            clearTimeout(timer);
+            controller.abort();
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [endpoint, tipo, filtrosSerializados]);
+
+    return { dados, status, erro };
+}

--- a/resources/js/hooks/use-gerar-relatorio.ts
+++ b/resources/js/hooks/use-gerar-relatorio.ts
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { FormatoRelatorio, FiltrosRelatorio, TipoRelatorio } from '@/types';
+
+interface PayloadGerarRelatorio {
+    tipo: TipoRelatorio;
+    formato: FormatoRelatorio;
+    filtros?: FiltrosRelatorio;
+}
+
+export function useGerarRelatorio(endpoint: string) {
+    const [estaGerando, setEstaGerando] = useState(false);
+
+    const gerar = async (payload: PayloadGerarRelatorio) => {
+        setEstaGerando(true);
+
+        try {
+            const csrfToken =
+                document.querySelector('meta[name=csrf-token]')?.getAttribute('content') ?? '';
+
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': csrfToken,
+                    'X-Requested-With': 'XMLHttpRequest',
+                    Accept: 'application/pdf, text/csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                },
+                body: JSON.stringify({
+                    tipo: payload.tipo,
+                    formato: payload.formato,
+                    ...payload.filtros,
+                }),
+            });
+
+            if (!response.ok) {
+                if (response.status === 422) {
+                    try {
+                        const data = await response.json();
+                        toast.error(data.message || 'Erro ao gerar relatório.');
+                    } catch {
+                        toast.error('Erro ao gerar relatório.');
+                    }
+                } else {
+                    toast.error('Erro ao gerar relatório.');
+                }
+                return;
+            }
+
+            const blob = await response.blob();
+
+            const contentDisposition = response.headers.get('content-disposition');
+            let filename = 'relatorio.pdf';
+
+            if (contentDisposition) {
+                const match = contentDisposition.match(/filename="([^"]+)"/);
+                if (match && match[1]) {
+                    filename = match[1];
+                }
+            }
+
+            const url = URL.createObjectURL(blob);
+            const anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.download = filename;
+            document.body.appendChild(anchor);
+            anchor.click();
+            document.body.removeChild(anchor);
+            URL.revokeObjectURL(url);
+
+            toast.success('Relatório gerado com sucesso.');
+        } finally {
+            setEstaGerando(false);
+        }
+    };
+
+    return { gerar, estaGerando };
+}

--- a/resources/js/hooks/use-gerar-relatorio.ts
+++ b/resources/js/hooks/use-gerar-relatorio.ts
@@ -15,18 +15,32 @@ export function useGerarRelatorio(endpoint: string) {
         setEstaGerando(true);
 
         try {
-            const csrfToken =
-                document.querySelector('meta[name=csrf-token]')?.getAttribute('content') ?? '';
+            const metaToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+            const xsrfCookie = decodeURIComponent(
+                document.cookie
+                    .split('; ')
+                    .find((r) => r.startsWith('XSRF-TOKEN='))
+                    ?.split('=')[1] ?? ''
+            );
+
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+                Accept: 'application/pdf, text/csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            };
+
+            // Prioriza o cookie XSRF-TOKEN (renovado pelo Laravel a cada resposta) sobre a
+            // meta tag, que fica desatualizada apos o login numa SPA Inertia (sem reload).
+            if (xsrfCookie) {
+                headers['X-XSRF-TOKEN'] = xsrfCookie;
+            } else if (metaToken) {
+                headers['X-CSRF-TOKEN'] = metaToken;
+            }
 
             const response = await fetch(endpoint, {
                 method: 'POST',
                 credentials: 'same-origin',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': csrfToken,
-                    'X-Requested-With': 'XMLHttpRequest',
-                    Accept: 'application/pdf, text/csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                },
+                headers,
                 body: JSON.stringify({
                     tipo: payload.tipo,
                     formato: payload.formato,
@@ -51,12 +65,15 @@ export function useGerarRelatorio(endpoint: string) {
             const blob = await response.blob();
 
             const contentDisposition = response.headers.get('content-disposition');
-            let filename = 'relatorio.pdf';
+            // Fallback com a extensao do formato solicitado: o header pode faltar ou
+            // vir sem aspas, e nunca devemos salvar CSV/XLSX com extensao .pdf.
+            let filename = `relatorio.${payload.formato}`;
 
             if (contentDisposition) {
-                const match = contentDisposition.match(/filename="([^"]+)"/);
+                // Aceita filename com ou sem aspas (o backend envia sem aspas).
+                const match = contentDisposition.match(/filename\*?=(?:UTF-8'')?"?([^";]+)"?/i);
                 if (match && match[1]) {
-                    filename = match[1];
+                    filename = decodeURIComponent(match[1].trim());
                 }
             }
 

--- a/resources/js/presentation/molecules/ComboboxFiltro.tsx
+++ b/resources/js/presentation/molecules/ComboboxFiltro.tsx
@@ -1,0 +1,116 @@
+import { useMemo, useState } from 'react';
+import { Check, ChevronsUpDown, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+export interface OpcaoCombobox {
+    id: number;
+    nome: string;
+}
+
+interface Props {
+    opcoes: OpcaoCombobox[];
+    value?: number;
+    onChange: (value: number | undefined) => void;
+    placeholder?: string;
+    placeholderBusca?: string;
+    vazio?: string;
+    disabled?: boolean;
+    id?: string;
+}
+
+export function ComboboxFiltro({
+    opcoes,
+    value,
+    onChange,
+    placeholder = 'Todos',
+    placeholderBusca = 'Buscar...',
+    vazio = 'Nenhum resultado.',
+    disabled = false,
+    id,
+}: Props) {
+    const [aberto, setAberto] = useState(false);
+
+    const selecionada = useMemo(
+        () => opcoes.find((opcao) => opcao.id === value),
+        [opcoes, value]
+    );
+
+    const handleSelect = (opcaoId: number) => {
+        onChange(opcaoId === value ? undefined : opcaoId);
+        setAberto(false);
+    };
+
+    return (
+        <Popover open={aberto} onOpenChange={setAberto}>
+            <PopoverTrigger asChild>
+                <Button
+                    id={id}
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={aberto}
+                    disabled={disabled}
+                    className="w-full justify-between font-normal"
+                >
+                    <span className={cn('truncate', !selecionada && 'text-muted-foreground')}>
+                        {selecionada ? selecionada.nome : placeholder}
+                    </span>
+                    <span className="flex items-center gap-1">
+                        {selecionada && (
+                            <span
+                                role="button"
+                                aria-label="Limpar seleção"
+                                className="hover:bg-muted flex h-4 w-4 items-center justify-center rounded"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    onChange(undefined);
+                                }}
+                            >
+                                <X className="h-3 w-3" />
+                            </span>
+                        )}
+                        <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+                    </span>
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent
+                className="w-[var(--radix-popover-trigger-width)] p-0"
+                align="start"
+            >
+                <Command>
+                    <CommandInput placeholder={placeholderBusca} />
+                    <CommandList>
+                        <CommandEmpty>{vazio}</CommandEmpty>
+                        <CommandGroup>
+                            {opcoes.map((opcao) => (
+                                <CommandItem
+                                    key={opcao.id}
+                                    value={opcao.nome}
+                                    onSelect={() => handleSelect(opcao.id)}
+                                >
+                                    <Check
+                                        className={cn(
+                                            'mr-2 h-4 w-4',
+                                            opcao.id === value ? 'opacity-100' : 'opacity-0'
+                                        )}
+                                    />
+                                    {opcao.nome}
+                                </CommandItem>
+                            ))}
+                        </CommandGroup>
+                    </CommandList>
+                </Command>
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/resources/js/presentation/molecules/ExportarRelatorio.tsx
+++ b/resources/js/presentation/molecules/ExportarRelatorio.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { FormatoRelatorio } from '@/types';
+import { ChevronDown, Download, Loader2 } from 'lucide-react';
+
+interface Props {
+    onExport: (formato: FormatoRelatorio) => void;
+    estaGerando: boolean;
+    disabled?: boolean;
+}
+
+const FORMATOS: Array<{ value: FormatoRelatorio; label: string }> = [
+    { value: 'pdf', label: 'PDF' },
+    { value: 'csv', label: 'CSV' },
+    { value: 'xlsx', label: 'XLSX' },
+];
+
+export function ExportarRelatorio({ onExport, estaGerando, disabled }: Props) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button variant="outline" disabled={disabled || estaGerando} className="gap-2">
+                    {estaGerando ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                        <Download className="h-4 w-4" />
+                    )}
+                    {estaGerando ? 'Gerando...' : 'Exportar'}
+                    <ChevronDown className="text-muted-foreground h-4 w-4" />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuLabel>Formato</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {FORMATOS.map((formato) => (
+                    <DropdownMenuItem key={formato.value} onSelect={() => onExport(formato.value)}>
+                        {formato.label}
+                    </DropdownMenuItem>
+                ))}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/resources/js/presentation/molecules/FiltroChips.tsx
+++ b/resources/js/presentation/molecules/FiltroChips.tsx
@@ -1,0 +1,43 @@
+import { Label } from '@/components/ui/label';
+import { Toggle } from '@/components/ui/toggle';
+
+interface Opcao {
+    value: string;
+    label: string;
+}
+
+interface Props {
+    label: string;
+    opcoes: Opcao[];
+    selecionados: string[];
+    onChange: (valores: string[]) => void;
+}
+
+export function FiltroChips({ label, opcoes, selecionados, onChange }: Props) {
+    return (
+        <div className="space-y-2">
+            <Label className="block">{label}</Label>
+            <div className="flex flex-wrap gap-2">
+                {opcoes.map((opcao) => (
+                    <Toggle
+                        key={opcao.value}
+                        pressed={selecionados.includes(opcao.value)}
+                        onPressedChange={(on) =>
+                            onChange(
+                                on
+                                    ? [...selecionados, opcao.value]
+                                    : selecionados.filter((v) => v !== opcao.value)
+                            )
+                        }
+                        variant="outline"
+                        size="sm"
+                        className="rounded-full px-3 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary"
+                        aria-label={opcao.label}
+                    >
+                        {opcao.label}
+                    </Toggle>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/presentation/molecules/FiltrosIndicadoresConsolidados.tsx
+++ b/resources/js/presentation/molecules/FiltrosIndicadoresConsolidados.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { FiltrosRelatorio } from '@/types';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { CalendarIcon } from 'lucide-react';
+
+interface Props {
+    filtros: Partial<FiltrosRelatorio>;
+    onChange: (filtros: Partial<FiltrosRelatorio>) => void;
+}
+
+export function FiltrosIndicadoresConsolidados({ filtros, onChange }: Props) {
+    const [dataInicio, setDataInicio] = useState<Date | undefined>(
+        filtros.data_inicio ? new Date(filtros.data_inicio) : undefined
+    );
+    const [dataFim, setDataFim] = useState<Date | undefined>(
+        filtros.data_fim ? new Date(filtros.data_fim) : undefined
+    );
+
+    const handleDataInicioChange = (date: Date | undefined) => {
+        setDataInicio(date);
+        onChange({
+            ...filtros,
+            data_inicio: date ? format(date, 'yyyy-MM-dd') : undefined,
+        });
+    };
+
+    const handleDataFimChange = (date: Date | undefined) => {
+        setDataFim(date);
+        onChange({
+            ...filtros,
+            data_fim: date ? format(date, 'yyyy-MM-dd') : undefined,
+        });
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <Label className="mb-2 block">Data Início</Label>
+                    <Popover>
+                        <PopoverTrigger asChild>
+                            <Button variant="outline" className="w-full justify-start text-left font-normal">
+                                <CalendarIcon className="mr-2 h-4 w-4" />
+                                {dataInicio ? format(dataInicio, 'dd/MM/yyyy', { locale: ptBR }) : 'Selecione...'}
+                            </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                            <Calendar mode="single" selected={dataInicio} onSelect={handleDataInicioChange} />
+                        </PopoverContent>
+                    </Popover>
+                </div>
+
+                <div>
+                    <Label className="mb-2 block">Data Fim</Label>
+                    <Popover>
+                        <PopoverTrigger asChild>
+                            <Button variant="outline" className="w-full justify-start text-left font-normal">
+                                <CalendarIcon className="mr-2 h-4 w-4" />
+                                {dataFim ? format(dataFim, 'dd/MM/yyyy', { locale: ptBR }) : 'Selecione...'}
+                            </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                            <Calendar mode="single" selected={dataFim} onSelect={handleDataFimChange} />
+                        </PopoverContent>
+                    </Popover>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/presentation/molecules/FiltrosInventarioEspacos.tsx
+++ b/resources/js/presentation/molecules/FiltrosInventarioEspacos.tsx
@@ -1,0 +1,74 @@
+import { FiltrosRelatorio } from '@/types';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface Props {
+    filtros: Partial<FiltrosRelatorio>;
+    onChange: (filtros: Partial<FiltrosRelatorio>) => void;
+}
+
+export function FiltrosInventarioEspacos({ filtros, onChange }: Props) {
+    const handleChange = (field: string, value: string) => {
+        const numValue = value ? parseInt(value, 10) : undefined;
+        onChange({
+            ...filtros,
+            [field]: numValue,
+        });
+    };
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <Label htmlFor="unidade_id" className="mb-2 block">
+                    ID Unidade
+                </Label>
+                <Input
+                    id="unidade_id"
+                    type="number"
+                    placeholder="Deixe em branco para ver todas"
+                    value={filtros.unidade_id || ''}
+                    onChange={(e) => handleChange('unidade_id', e.target.value)}
+                />
+            </div>
+
+            <div>
+                <Label htmlFor="modulo_id" className="mb-2 block">
+                    ID Módulo
+                </Label>
+                <Input
+                    id="modulo_id"
+                    type="number"
+                    placeholder="Deixe em branco para ver todos"
+                    value={filtros.modulo_id || ''}
+                    onChange={(e) => handleChange('modulo_id', e.target.value)}
+                />
+            </div>
+
+            <div>
+                <Label htmlFor="andar_id" className="mb-2 block">
+                    ID Andar
+                </Label>
+                <Input
+                    id="andar_id"
+                    type="number"
+                    placeholder="Deixe em branco para ver todos"
+                    value={filtros.andar_id || ''}
+                    onChange={(e) => handleChange('andar_id', e.target.value)}
+                />
+            </div>
+
+            <div>
+                <Label htmlFor="espaco_id" className="mb-2 block">
+                    ID Espaço
+                </Label>
+                <Input
+                    id="espaco_id"
+                    type="number"
+                    placeholder="Deixe em branco para ver todos"
+                    value={filtros.espaco_id || ''}
+                    onChange={(e) => handleChange('espaco_id', e.target.value)}
+                />
+            </div>
+        </div>
+    );
+}

--- a/resources/js/presentation/molecules/FiltrosInventarioEspacos.tsx
+++ b/resources/js/presentation/molecules/FiltrosInventarioEspacos.tsx
@@ -1,72 +1,117 @@
-import { FiltrosRelatorio } from '@/types';
-import { Input } from '@/components/ui/input';
+import { useMemo } from 'react';
 import { Label } from '@/components/ui/label';
+import { ComboboxFiltro } from '@/presentation/molecules/ComboboxFiltro';
+import { FiltrosRelatorio, OpcoesInventario } from '@/types';
 
 interface Props {
     filtros: Partial<FiltrosRelatorio>;
+    opcoes: OpcoesInventario;
     onChange: (filtros: Partial<FiltrosRelatorio>) => void;
 }
 
-export function FiltrosInventarioEspacos({ filtros, onChange }: Props) {
-    const handleChange = (field: string, value: string) => {
-        const numValue = value ? parseInt(value, 10) : undefined;
+export function FiltrosInventarioEspacos({ filtros, opcoes, onChange }: Props) {
+    // Cada nivel so lista o que pertence ao nivel anterior selecionado.
+    const modulos = useMemo(
+        () =>
+            filtros.unidade_id
+                ? opcoes.modulos.filter((modulo) => modulo.unidade_id === filtros.unidade_id)
+                : opcoes.modulos,
+        [opcoes.modulos, filtros.unidade_id]
+    );
+
+    const andares = useMemo(() => {
+        const idsModulos = new Set(modulos.map((modulo) => modulo.id));
+
+        return filtros.modulo_id
+            ? opcoes.andares.filter((andar) => andar.modulo_id === filtros.modulo_id)
+            : opcoes.andares.filter((andar) => idsModulos.has(andar.modulo_id));
+    }, [opcoes.andares, modulos, filtros.modulo_id]);
+
+    const espacos = useMemo(() => {
+        const idsAndares = new Set(andares.map((andar) => andar.id));
+
+        return filtros.andar_id
+            ? opcoes.espacos.filter((espaco) => espaco.andar_id === filtros.andar_id)
+            : opcoes.espacos.filter((espaco) => idsAndares.has(espaco.andar_id));
+    }, [opcoes.espacos, andares, filtros.andar_id]);
+
+    // Trocar um nivel invalida os niveis abaixo dele.
+    const handleUnidade = (unidade_id?: number) =>
         onChange({
             ...filtros,
-            [field]: numValue,
+            unidade_id,
+            modulo_id: undefined,
+            andar_id: undefined,
+            espaco_id: undefined,
         });
-    };
+
+    const handleModulo = (modulo_id?: number) =>
+        onChange({ ...filtros, modulo_id, andar_id: undefined, espaco_id: undefined });
+
+    const handleAndar = (andar_id?: number) =>
+        onChange({ ...filtros, andar_id, espaco_id: undefined });
+
+    const handleEspaco = (espaco_id?: number) => onChange({ ...filtros, espaco_id });
 
     return (
-        <div className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <div>
                 <Label htmlFor="unidade_id" className="mb-2 block">
-                    ID Unidade
+                    Unidade
                 </Label>
-                <Input
+                <ComboboxFiltro
                     id="unidade_id"
-                    type="number"
-                    placeholder="Deixe em branco para ver todas"
-                    value={filtros.unidade_id || ''}
-                    onChange={(e) => handleChange('unidade_id', e.target.value)}
+                    opcoes={opcoes.unidades}
+                    value={filtros.unidade_id}
+                    onChange={handleUnidade}
+                    placeholder="Todas as unidades"
+                    placeholderBusca="Buscar unidade..."
+                    vazio="Nenhuma unidade encontrada."
                 />
             </div>
 
             <div>
                 <Label htmlFor="modulo_id" className="mb-2 block">
-                    ID Módulo
+                    Módulo
                 </Label>
-                <Input
+                <ComboboxFiltro
                     id="modulo_id"
-                    type="number"
-                    placeholder="Deixe em branco para ver todos"
-                    value={filtros.modulo_id || ''}
-                    onChange={(e) => handleChange('modulo_id', e.target.value)}
+                    opcoes={modulos}
+                    value={filtros.modulo_id}
+                    onChange={handleModulo}
+                    placeholder="Todos os módulos"
+                    placeholderBusca="Buscar módulo..."
+                    vazio="Nenhum módulo encontrado."
                 />
             </div>
 
             <div>
                 <Label htmlFor="andar_id" className="mb-2 block">
-                    ID Andar
+                    Andar
                 </Label>
-                <Input
+                <ComboboxFiltro
                     id="andar_id"
-                    type="number"
-                    placeholder="Deixe em branco para ver todos"
-                    value={filtros.andar_id || ''}
-                    onChange={(e) => handleChange('andar_id', e.target.value)}
+                    opcoes={andares}
+                    value={filtros.andar_id}
+                    onChange={handleAndar}
+                    placeholder="Todos os andares"
+                    placeholderBusca="Buscar andar..."
+                    vazio="Nenhum andar encontrado."
                 />
             </div>
 
             <div>
                 <Label htmlFor="espaco_id" className="mb-2 block">
-                    ID Espaço
+                    Espaço
                 </Label>
-                <Input
+                <ComboboxFiltro
                     id="espaco_id"
-                    type="number"
-                    placeholder="Deixe em branco para ver todos"
-                    value={filtros.espaco_id || ''}
-                    onChange={(e) => handleChange('espaco_id', e.target.value)}
+                    opcoes={espacos}
+                    value={filtros.espaco_id}
+                    onChange={handleEspaco}
+                    placeholder="Todos os espaços"
+                    placeholderBusca="Buscar espaço..."
+                    vazio="Nenhum espaço encontrado."
                 />
             </div>
         </div>

--- a/resources/js/presentation/molecules/FiltrosOcupacaoEspacos.tsx
+++ b/resources/js/presentation/molecules/FiltrosOcupacaoEspacos.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { FiltroChips } from '@/presentation/molecules/FiltroChips';
 import { FiltrosRelatorio } from '@/types';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -44,8 +45,8 @@ export function FiltrosOcupacaoEspacos({ filtros, onChange }: Props) {
     };
 
     return (
-        <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+            <div className="grid gap-4 md:grid-cols-2">
                 <div>
                     <Label className="mb-2 block">Data Início</Label>
                     <Popover>
@@ -77,34 +78,18 @@ export function FiltrosOcupacaoEspacos({ filtros, onChange }: Props) {
                 </div>
             </div>
 
-            <div>
-                <Label className="mb-2 block">Turnos</Label>
-                <div className="space-y-2">
-                    {turnos.map((turno) => (
-                        <label key={turno.value} className="flex items-center space-x-2">
-                            <input
-                                type="checkbox"
-                                checked={(filtros.turnos || []).includes(turno.value as 'manha' | 'tarde' | 'noite')}
-                                onChange={(e) => {
-                                    const turnosSelecionados = filtros.turnos || [];
-                                    if (e.target.checked) {
-                                        onChange({
-                                            ...filtros,
-                                            turnos: [...turnosSelecionados, turno.value as 'manha' | 'tarde' | 'noite'],
-                                        });
-                                    } else {
-                                        onChange({
-                                            ...filtros,
-                                            turnos: turnosSelecionados.filter((t) => t !== turno.value),
-                                        });
-                                    }
-                                }}
-                                className="h-4 w-4"
-                            />
-                            <span>{turno.label}</span>
-                        </label>
-                    ))}
-                </div>
+            <div className="pt-2">
+                <FiltroChips
+                    label="Turnos"
+                    opcoes={turnos}
+                    selecionados={filtros.turnos ?? []}
+                    onChange={(valores) =>
+                        onChange({
+                            ...filtros,
+                            turnos: valores as Array<'manha' | 'tarde' | 'noite'>,
+                        })
+                    }
+                />
             </div>
         </div>
     );

--- a/resources/js/presentation/molecules/FiltrosOcupacaoEspacos.tsx
+++ b/resources/js/presentation/molecules/FiltrosOcupacaoEspacos.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { FiltrosRelatorio } from '@/types';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { CalendarIcon } from 'lucide-react';
+
+interface Props {
+    filtros: Partial<FiltrosRelatorio>;
+    onChange: (filtros: Partial<FiltrosRelatorio>) => void;
+}
+
+export function FiltrosOcupacaoEspacos({ filtros, onChange }: Props) {
+    const [dataInicio, setDataInicio] = useState<Date | undefined>(
+        filtros.data_inicio ? new Date(filtros.data_inicio) : undefined
+    );
+    const [dataFim, setDataFim] = useState<Date | undefined>(
+        filtros.data_fim ? new Date(filtros.data_fim) : undefined
+    );
+
+    const turnos = [
+        { value: 'manha', label: 'Manhã' },
+        { value: 'tarde', label: 'Tarde' },
+        { value: 'noite', label: 'Noite' },
+    ];
+
+    const handleDataInicioChange = (date: Date | undefined) => {
+        setDataInicio(date);
+        onChange({
+            ...filtros,
+            data_inicio: date ? format(date, 'yyyy-MM-dd') : undefined,
+        });
+    };
+
+    const handleDataFimChange = (date: Date | undefined) => {
+        setDataFim(date);
+        onChange({
+            ...filtros,
+            data_fim: date ? format(date, 'yyyy-MM-dd') : undefined,
+        });
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <Label className="mb-2 block">Data Início</Label>
+                    <Popover>
+                        <PopoverTrigger asChild>
+                            <Button variant="outline" className="w-full justify-start text-left font-normal">
+                                <CalendarIcon className="mr-2 h-4 w-4" />
+                                {dataInicio ? format(dataInicio, 'dd/MM/yyyy', { locale: ptBR }) : 'Selecione...'}
+                            </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                            <Calendar mode="single" selected={dataInicio} onSelect={handleDataInicioChange} />
+                        </PopoverContent>
+                    </Popover>
+                </div>
+
+                <div>
+                    <Label className="mb-2 block">Data Fim</Label>
+                    <Popover>
+                        <PopoverTrigger asChild>
+                            <Button variant="outline" className="w-full justify-start text-left font-normal">
+                                <CalendarIcon className="mr-2 h-4 w-4" />
+                                {dataFim ? format(dataFim, 'dd/MM/yyyy', { locale: ptBR }) : 'Selecione...'}
+                            </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                            <Calendar mode="single" selected={dataFim} onSelect={handleDataFimChange} />
+                        </PopoverContent>
+                    </Popover>
+                </div>
+            </div>
+
+            <div>
+                <Label className="mb-2 block">Turnos</Label>
+                <div className="space-y-2">
+                    {turnos.map((turno) => (
+                        <label key={turno.value} className="flex items-center space-x-2">
+                            <input
+                                type="checkbox"
+                                checked={(filtros.turnos || []).includes(turno.value as 'manha' | 'tarde' | 'noite')}
+                                onChange={(e) => {
+                                    const turnosSelecionados = filtros.turnos || [];
+                                    if (e.target.checked) {
+                                        onChange({
+                                            ...filtros,
+                                            turnos: [...turnosSelecionados, turno.value as 'manha' | 'tarde' | 'noite'],
+                                        });
+                                    } else {
+                                        onChange({
+                                            ...filtros,
+                                            turnos: turnosSelecionados.filter((t) => t !== turno.value),
+                                        });
+                                    }
+                                }}
+                                className="h-4 w-4"
+                            />
+                            <span>{turno.label}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/presentation/molecules/FiltrosReservasPeriodo.tsx
+++ b/resources/js/presentation/molecules/FiltrosReservasPeriodo.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { FiltroChips } from '@/presentation/molecules/FiltroChips';
 import { FiltrosRelatorio, SituacaoReserva } from '@/types';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -51,8 +52,8 @@ export function FiltrosReservasPeriodo({ filtros, onChange }: Props) {
     };
 
     return (
-        <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+            <div className="grid gap-4 md:grid-cols-2">
                 <div>
                     <Label className="mb-2 block">Data Início</Label>
                     <Popover>
@@ -84,64 +85,27 @@ export function FiltrosReservasPeriodo({ filtros, onChange }: Props) {
                 </div>
             </div>
 
-            <div>
-                <Label className="mb-2 block">Situações</Label>
-                <div className="space-y-2">
-                    {situacoes.map((situacao) => (
-                        <label key={situacao.value} className="flex items-center space-x-2">
-                            <input
-                                type="checkbox"
-                                checked={(filtros.situacoes || []).includes(situacao.value)}
-                                onChange={(e) => {
-                                    const situacoesSelecionadas = filtros.situacoes || [];
-                                    if (e.target.checked) {
-                                        onChange({
-                                            ...filtros,
-                                            situacoes: [...situacoesSelecionadas, situacao.value],
-                                        });
-                                    } else {
-                                        onChange({
-                                            ...filtros,
-                                            situacoes: situacoesSelecionadas.filter((s) => s !== situacao.value),
-                                        });
-                                    }
-                                }}
-                                className="h-4 w-4"
-                            />
-                            <span>{situacao.label}</span>
-                        </label>
-                    ))}
-                </div>
-            </div>
+            <div className="pt-2 space-y-2">
+                <FiltroChips
+                    label="Situações"
+                    opcoes={situacoes}
+                    selecionados={filtros.situacoes ?? []}
+                    onChange={(valores) =>
+                        onChange({ ...filtros, situacoes: valores as SituacaoReserva[] })
+                    }
+                />
 
-            <div>
-                <Label className="mb-2 block">Turnos</Label>
-                <div className="space-y-2">
-                    {turnos.map((turno) => (
-                        <label key={turno.value} className="flex items-center space-x-2">
-                            <input
-                                type="checkbox"
-                                checked={(filtros.turnos || []).includes(turno.value as 'manha' | 'tarde' | 'noite')}
-                                onChange={(e) => {
-                                    const turnosSelecionados = filtros.turnos || [];
-                                    if (e.target.checked) {
-                                        onChange({
-                                            ...filtros,
-                                            turnos: [...turnosSelecionados, turno.value as 'manha' | 'tarde' | 'noite'],
-                                        });
-                                    } else {
-                                        onChange({
-                                            ...filtros,
-                                            turnos: turnosSelecionados.filter((t) => t !== turno.value),
-                                        });
-                                    }
-                                }}
-                                className="h-4 w-4"
-                            />
-                            <span>{turno.label}</span>
-                        </label>
-                    ))}
-                </div>
+                <FiltroChips
+                    label="Turnos"
+                    opcoes={turnos}
+                    selecionados={filtros.turnos ?? []}
+                    onChange={(valores) =>
+                        onChange({
+                            ...filtros,
+                            turnos: valores as Array<'manha' | 'tarde' | 'noite'>,
+                        })
+                    }
+                />
             </div>
         </div>
     );

--- a/resources/js/presentation/molecules/FiltrosReservasPeriodo.tsx
+++ b/resources/js/presentation/molecules/FiltrosReservasPeriodo.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { FiltrosRelatorio, SituacaoReserva } from '@/types';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { CalendarIcon } from 'lucide-react';
+
+interface Props {
+    filtros: Partial<FiltrosRelatorio>;
+    onChange: (filtros: Partial<FiltrosRelatorio>) => void;
+}
+
+export function FiltrosReservasPeriodo({ filtros, onChange }: Props) {
+    const [dataInicio, setDataInicio] = useState<Date | undefined>(
+        filtros.data_inicio ? new Date(filtros.data_inicio) : undefined
+    );
+    const [dataFim, setDataFim] = useState<Date | undefined>(
+        filtros.data_fim ? new Date(filtros.data_fim) : undefined
+    );
+
+    const situacoes: Array<{ value: SituacaoReserva; label: string }> = [
+        { value: 'em_analise', label: 'Em Análise' },
+        { value: 'deferida', label: 'Deferida' },
+        { value: 'indeferida', label: 'Indeferida' },
+        { value: 'parcialmente_deferida', label: 'Parcialmente Deferida' },
+    ];
+
+    const turnos = [
+        { value: 'manha', label: 'Manhã' },
+        { value: 'tarde', label: 'Tarde' },
+        { value: 'noite', label: 'Noite' },
+    ];
+
+    const handleDataInicioChange = (date: Date | undefined) => {
+        setDataInicio(date);
+        onChange({
+            ...filtros,
+            data_inicio: date ? format(date, 'yyyy-MM-dd') : undefined,
+        });
+    };
+
+    const handleDataFimChange = (date: Date | undefined) => {
+        setDataFim(date);
+        onChange({
+            ...filtros,
+            data_fim: date ? format(date, 'yyyy-MM-dd') : undefined,
+        });
+    };
+
+    return (
+        <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <Label className="mb-2 block">Data Início</Label>
+                    <Popover>
+                        <PopoverTrigger asChild>
+                            <Button variant="outline" className="w-full justify-start text-left font-normal">
+                                <CalendarIcon className="mr-2 h-4 w-4" />
+                                {dataInicio ? format(dataInicio, 'dd/MM/yyyy', { locale: ptBR }) : 'Selecione...'}
+                            </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                            <Calendar mode="single" selected={dataInicio} onSelect={handleDataInicioChange} />
+                        </PopoverContent>
+                    </Popover>
+                </div>
+
+                <div>
+                    <Label className="mb-2 block">Data Fim</Label>
+                    <Popover>
+                        <PopoverTrigger asChild>
+                            <Button variant="outline" className="w-full justify-start text-left font-normal">
+                                <CalendarIcon className="mr-2 h-4 w-4" />
+                                {dataFim ? format(dataFim, 'dd/MM/yyyy', { locale: ptBR }) : 'Selecione...'}
+                            </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                            <Calendar mode="single" selected={dataFim} onSelect={handleDataFimChange} />
+                        </PopoverContent>
+                    </Popover>
+                </div>
+            </div>
+
+            <div>
+                <Label className="mb-2 block">Situações</Label>
+                <div className="space-y-2">
+                    {situacoes.map((situacao) => (
+                        <label key={situacao.value} className="flex items-center space-x-2">
+                            <input
+                                type="checkbox"
+                                checked={(filtros.situacoes || []).includes(situacao.value)}
+                                onChange={(e) => {
+                                    const situacoesSelecionadas = filtros.situacoes || [];
+                                    if (e.target.checked) {
+                                        onChange({
+                                            ...filtros,
+                                            situacoes: [...situacoesSelecionadas, situacao.value],
+                                        });
+                                    } else {
+                                        onChange({
+                                            ...filtros,
+                                            situacoes: situacoesSelecionadas.filter((s) => s !== situacao.value),
+                                        });
+                                    }
+                                }}
+                                className="h-4 w-4"
+                            />
+                            <span>{situacao.label}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+
+            <div>
+                <Label className="mb-2 block">Turnos</Label>
+                <div className="space-y-2">
+                    {turnos.map((turno) => (
+                        <label key={turno.value} className="flex items-center space-x-2">
+                            <input
+                                type="checkbox"
+                                checked={(filtros.turnos || []).includes(turno.value as 'manha' | 'tarde' | 'noite')}
+                                onChange={(e) => {
+                                    const turnosSelecionados = filtros.turnos || [];
+                                    if (e.target.checked) {
+                                        onChange({
+                                            ...filtros,
+                                            turnos: [...turnosSelecionados, turno.value as 'manha' | 'tarde' | 'noite'],
+                                        });
+                                    } else {
+                                        onChange({
+                                            ...filtros,
+                                            turnos: turnosSelecionados.filter((t) => t !== turno.value),
+                                        });
+                                    }
+                                }}
+                                className="h-4 w-4"
+                            />
+                            <span>{turno.label}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/presentation/molecules/GraficoIndicadoresConsolidados.tsx
+++ b/resources/js/presentation/molecules/GraficoIndicadoresConsolidados.tsx
@@ -1,0 +1,188 @@
+import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, XAxis, YAxis } from 'recharts';
+import { Building, CalendarCheck, Users } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    ChartConfig,
+    ChartContainer,
+    ChartLegend,
+    ChartLegendContent,
+    ChartTooltip,
+    ChartTooltipContent,
+} from '@/components/ui/chart';
+import { DadosRelatorio } from '@/types';
+
+interface Props {
+    dados: DadosRelatorio;
+}
+
+const CORES = [
+    'var(--chart-1)',
+    'var(--chart-2)',
+    'var(--chart-3)',
+    'var(--chart-4)',
+    'var(--chart-5)',
+];
+
+const situacoesConfig = {
+    total: {
+        label: 'Reservas',
+        color: 'var(--chart-1)',
+    },
+} satisfies ChartConfig;
+
+function numero(valor: unknown): number {
+    return Number(valor ?? 0);
+}
+
+function GraficoIndicadoresConsolidados({ dados }: Props) {
+    if (dados.linhas.length === 0) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle>{dados.titulo}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-muted-foreground text-sm">
+                        Nenhum indicador para os filtros selecionados.
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const situacoes = dados.linhas
+        .filter((linha) => String(linha.metrica ?? '').startsWith('Reservas '))
+        .map((linha) => ({
+            situacao: String(linha.metrica).replace('Reservas ', ''),
+            total: numero(linha.valor),
+        }));
+
+    const inicioTopEspacos = dados.linhas.findIndex(
+        (linha) => linha.metrica === '— Top 5 Espaços —'
+    );
+    const inicioTopSetores = dados.linhas.findIndex(
+        (linha) => linha.metrica === '— Top 5 Setores —'
+    );
+
+    const topEspacos =
+        inicioTopEspacos === -1
+            ? []
+            : dados.linhas
+                  .slice(
+                      inicioTopEspacos + 1,
+                      inicioTopSetores === -1 ? undefined : inicioTopSetores
+                  )
+                  .map((linha) => ({
+                      nome: String(linha.metrica ?? ''),
+                      count: numero(linha.valor),
+                  }));
+
+    return (
+        <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Total de Espaços</CardTitle>
+                        <Building className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">
+                            {numero(dados.sumario['Total de Espaços'])}
+                        </div>
+                        <p className="text-muted-foreground text-xs">Espaços cadastrados</p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Total de Gestores</CardTitle>
+                        <Users className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">
+                            {numero(dados.sumario['Total de Gestores'])}
+                        </div>
+                        <p className="text-muted-foreground text-xs">Gestores delegados</p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Total de Reservas</CardTitle>
+                        <CalendarCheck className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">
+                            {numero(dados.sumario['Total de Reservas'])}
+                        </div>
+                        <p className="text-muted-foreground text-xs">Total de reservas</p>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Distribuição de Situações</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <ChartContainer
+                            config={situacoesConfig}
+                            className="aspect-auto h-[260px] w-full"
+                        >
+                            <BarChart accessibilityLayer data={situacoes}>
+                                <CartesianGrid vertical={false} />
+                                <XAxis dataKey="situacao" tickLine={false} axisLine={false} />
+                                <YAxis />
+                                <ChartTooltip content={<ChartTooltipContent />} />
+                                <Bar
+                                    dataKey="total"
+                                    fill="var(--color-total)"
+                                    radius={4}
+                                    maxBarSize={64}
+                                />
+                            </BarChart>
+                        </ChartContainer>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Top 5 Espaços</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {(() => {
+                            const chartConfig = topEspacos.reduce((acc, e, i) => {
+                                acc[e.nome] = { label: e.nome, color: CORES[i % CORES.length] };
+                                return acc;
+                            }, {} as ChartConfig);
+                            return (
+                                <ChartContainer
+                                    config={chartConfig}
+                                    className="aspect-auto h-[260px] w-full"
+                                >
+                                    <PieChart accessibilityLayer>
+                                        <ChartTooltip content={<ChartTooltipContent nameKey="nome" />} />
+                                        <Pie
+                                            data={topEspacos}
+                                            dataKey="count"
+                                            nameKey="nome"
+                                            innerRadius={60}
+                                        >
+                                            {topEspacos.map((espaco, index) => (
+                                                <Cell key={espaco.nome} fill={CORES[index % CORES.length]} />
+                                            ))}
+                                        </Pie>
+                                        <ChartLegend content={<ChartLegendContent nameKey="nome" />} />
+                                    </PieChart>
+                                </ChartContainer>
+                            );
+                        })()}
+                    </CardContent>
+                </Card>
+            </div>
+        </div>
+    );
+}
+
+export default GraficoIndicadoresConsolidados;

--- a/resources/js/presentation/molecules/GraficoInventarioEspacos.tsx
+++ b/resources/js/presentation/molecules/GraficoInventarioEspacos.tsx
@@ -1,0 +1,143 @@
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
+import { Building, Gauge, Layers, Users } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    ChartConfig,
+    ChartContainer,
+    ChartTooltip,
+    ChartTooltipContent,
+} from '@/components/ui/chart';
+import { TabelaDetalhamento } from '@/presentation/molecules/TabelaDetalhamento';
+import { DadosRelatorio } from '@/types';
+
+interface Props {
+    dados: DadosRelatorio;
+}
+
+const chartConfig = {
+    capacidade_pessoas: {
+        label: 'Capacidade',
+        color: 'var(--chart-1)',
+    },
+} satisfies ChartConfig;
+
+function GraficoInventarioEspacos({ dados }: Props) {
+    if (dados.linhas.length === 0) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle>{dados.titulo}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-muted-foreground text-sm">
+                        Nenhum espaço para os filtros selecionados.
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const topCapacidade = dados.linhas
+        .map((linha) => ({
+            nome: String(linha.nome ?? ''),
+            capacidade_pessoas: Number(linha.capacidade_pessoas ?? 0),
+        }))
+        .sort((a, b) => b.capacidade_pessoas - a.capacidade_pessoas)
+        .slice(0, 15);
+
+    const alturaGrafico = Math.max(200, topCapacidade.length * 32 + 48);
+
+    return (
+        <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Total de Espaços</CardTitle>
+                        <Building className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">
+                            {String(dados.sumario['Total de Espaços'] ?? '')}
+                        </div>
+                        <p className="text-muted-foreground text-xs">Cadastrados</p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Capacidade Total</CardTitle>
+                        <Layers className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">
+                            {String(dados.sumario['Capacidade Total'] ?? '')}
+                        </div>
+                        <p className="text-muted-foreground text-xs">Pessoas</p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Média de Capacidade</CardTitle>
+                        <Gauge className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">
+                            {String(dados.sumario['Média de Capacidade'] ?? '')}
+                        </div>
+                        <p className="text-muted-foreground text-xs">Por espaço</p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Gestores Únicos</CardTitle>
+                        <Users className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">
+                            {String(dados.sumario['Total de Gestores Únicos'] ?? '')}
+                        </div>
+                        <p className="text-muted-foreground text-xs">Delegados</p>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Top 15 Espaços por Capacidade</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <ChartContainer
+                        config={chartConfig}
+                        className="aspect-auto w-full"
+                        style={{ height: alturaGrafico }}
+                    >
+                        <BarChart accessibilityLayer data={topCapacidade} layout="vertical">
+                            <CartesianGrid horizontal={false} />
+                            <XAxis type="number" dataKey="capacidade_pessoas" />
+                            <YAxis
+                                type="category"
+                                dataKey="nome"
+                                width={140}
+                                tickLine={false}
+                                axisLine={false}
+                            />
+                            <ChartTooltip content={<ChartTooltipContent />} />
+                            <Bar
+                                dataKey="capacidade_pessoas"
+                                fill="var(--color-capacidade_pessoas)"
+                                radius={4}
+                                maxBarSize={24}
+                            />
+                        </BarChart>
+                    </ChartContainer>
+                </CardContent>
+            </Card>
+
+            <TabelaDetalhamento colunas={dados.colunas} linhas={dados.linhas} />
+        </div>
+    );
+}
+
+export default GraficoInventarioEspacos;

--- a/resources/js/presentation/molecules/GraficoOcupacaoEspacos.tsx
+++ b/resources/js/presentation/molecules/GraficoOcupacaoEspacos.tsx
@@ -1,0 +1,94 @@
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    ChartConfig,
+    ChartContainer,
+    ChartTooltip,
+    ChartTooltipContent,
+} from '@/components/ui/chart';
+import { TabelaDetalhamento } from '@/presentation/molecules/TabelaDetalhamento';
+import { DadosRelatorio } from '@/types';
+
+interface Props {
+    dados: DadosRelatorio;
+}
+
+const chartConfig = {
+    taxa_ocupacao_num: {
+        label: 'Taxa de Ocupação (%)',
+        color: 'var(--chart-1)',
+    },
+} satisfies ChartConfig;
+
+function GraficoOcupacaoEspacos({ dados }: Props) {
+    if (dados.linhas.length === 0) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">{dados.titulo}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-muted-foreground text-sm">
+                        Nenhum dado de ocupação para os filtros selecionados.
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const dadosGrafico = dados.linhas
+        .map((linha) => ({
+            nome_espaco: String(linha.nome_espaco ?? ''),
+            taxa_ocupacao_num: Number(linha.taxa_ocupacao_num ?? 0),
+        }))
+        .sort((a, b) => b.taxa_ocupacao_num - a.taxa_ocupacao_num)
+        .slice(0, 15);
+
+    const alturaGrafico = Math.max(200, dadosGrafico.length * 32 + 48);
+
+    return (
+        <div className="space-y-4">
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Taxa de Ocupação — Top 15</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <ChartContainer
+                        config={chartConfig}
+                        className="aspect-auto w-full"
+                        style={{ height: alturaGrafico }}
+                    >
+                        <BarChart accessibilityLayer data={dadosGrafico} layout="vertical">
+                            <CartesianGrid horizontal={false} />
+                            <XAxis type="number" dataKey="taxa_ocupacao_num" />
+                            <YAxis
+                                type="category"
+                                dataKey="nome_espaco"
+                                width={160}
+                                tickLine={false}
+                                axisLine={false}
+                            />
+                            <ChartTooltip
+                                content={
+                                    <ChartTooltipContent
+                                        formatter={(value) => `${Number(value).toFixed(2)}%`}
+                                    />
+                                }
+                            />
+                            <Bar
+                                dataKey="taxa_ocupacao_num"
+                                fill="var(--color-taxa_ocupacao_num)"
+                                radius={4}
+                                maxBarSize={24}
+                            />
+                        </BarChart>
+                    </ChartContainer>
+                </CardContent>
+            </Card>
+
+            <TabelaDetalhamento colunas={dados.colunas} linhas={dados.linhas} />
+        </div>
+    );
+}
+
+export default GraficoOcupacaoEspacos;

--- a/resources/js/presentation/molecules/GraficoReservasPeriodo.tsx
+++ b/resources/js/presentation/molecules/GraficoReservasPeriodo.tsx
@@ -1,0 +1,166 @@
+import { Cell, Pie, PieChart } from 'recharts';
+import { CalendarCheck, CircleCheck, CircleX, Clock } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    ChartConfig,
+    ChartContainer,
+    ChartLegend,
+    ChartLegendContent,
+    ChartTooltip,
+    ChartTooltipContent,
+} from '@/components/ui/chart';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { TabelaDetalhamento } from '@/presentation/molecules/TabelaDetalhamento';
+import { DadosRelatorio } from '@/types';
+
+interface Props {
+    dados: DadosRelatorio;
+}
+
+const CORES = ['var(--chart-2)', 'var(--chart-4)', 'var(--chart-3)'];
+
+function numero(valor: unknown): number {
+    return Number(valor ?? 0);
+}
+
+function GraficoReservasPeriodo({ dados }: Props) {
+    if (dados.linhas.length === 0) {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle>{dados.titulo}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-muted-foreground text-sm">
+                        Nenhuma reserva para os filtros selecionados.
+                    </p>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const distribuicao = [
+        { situacao: 'Deferidas', total: numero(dados.sumario['Deferidas']) },
+        { situacao: 'Indeferidas', total: numero(dados.sumario['Indeferidas']) },
+        { situacao: 'Em Análise', total: numero(dados.sumario['Em Análise']) },
+    ];
+
+    return (
+        <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Total de Reservas</CardTitle>
+                        <CalendarCheck className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">
+                            {numero(dados.sumario['Total de Reservas'])}
+                        </div>
+                        <p className="text-muted-foreground text-xs">No período</p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Deferidas</CardTitle>
+                        <CircleCheck className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">{numero(dados.sumario['Deferidas'])}</div>
+                        <p className="text-muted-foreground text-xs">Aprovadas</p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Indeferidas</CardTitle>
+                        <CircleX className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">{numero(dados.sumario['Indeferidas'])}</div>
+                        <p className="text-muted-foreground text-xs">Recusadas</p>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-sm font-medium">Em Análise</CardTitle>
+                        <Clock className="text-muted-foreground h-4 w-4" />
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">{numero(dados.sumario['Em Análise'])}</div>
+                        <p className="text-muted-foreground text-xs">Pendentes</p>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Distribuição por Situação</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {(() => {
+                            const chartConfig = distribuicao.reduce((acc, d, i) => {
+                                acc[d.situacao] = { label: d.situacao, color: CORES[i % CORES.length] };
+                                return acc;
+                            }, {} as ChartConfig);
+                            return (
+                                <ChartContainer
+                                    config={chartConfig}
+                                    className="aspect-auto h-[240px] w-full"
+                                >
+                                    <PieChart accessibilityLayer>
+                                        <ChartTooltip content={<ChartTooltipContent nameKey="situacao" />} />
+                                        <Pie data={distribuicao} dataKey="total" nameKey="situacao" innerRadius={60}>
+                                            {distribuicao.map((item, index) => (
+                                                <Cell key={item.situacao} fill={CORES[index % CORES.length]} />
+                                            ))}
+                                        </Pie>
+                                        <ChartLegend content={<ChartLegendContent nameKey="situacao" />} />
+                                    </PieChart>
+                                </ChartContainer>
+                            );
+                        })()}
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Resumo</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Situação</TableHead>
+                                    <TableHead>Total</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {distribuicao.map((item) => (
+                                    <TableRow key={item.situacao}>
+                                        <TableCell>{item.situacao}</TableCell>
+                                        <TableCell>{item.total}</TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <TabelaDetalhamento colunas={dados.colunas} linhas={dados.linhas} />
+        </div>
+    );
+}
+
+export default GraficoReservasPeriodo;

--- a/resources/js/presentation/molecules/TabelaDetalhamento.tsx
+++ b/resources/js/presentation/molecules/TabelaDetalhamento.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { Paginacao } from '@/presentation/molecules/Paginacao';
+import { cn } from '@/lib/utils';
+import { ColunaRelatorio } from '@/types';
+
+const OPCOES_POR_PAGINA = [10, 25, 50, 100];
+
+type Direcao = 'asc' | 'desc';
+
+interface Ordenacao {
+    chave: string;
+    direcao: Direcao;
+}
+
+interface Props {
+    titulo?: string;
+    colunas: ColunaRelatorio[];
+    linhas: Record<string, unknown>[];
+    itemsPerPage?: number;
+}
+
+const DATA_BR = /^(\d{2})\/(\d{2})\/(\d{4})(?:\s+(\d{2}):(\d{2}))?$/;
+
+/**
+ * Converte o valor exibido em algo comparavel. As linhas ja chegam
+ * formatadas do backend (datas em d/m/Y, taxas com "%"), entao a ordenacao
+ * precisa reinterpretar o texto antes de comparar.
+ */
+function valorOrdenavel(valor: unknown): number | string {
+    if (valor === null || valor === undefined) {
+        return '';
+    }
+
+    if (typeof valor === 'number') {
+        return valor;
+    }
+
+    if (typeof valor === 'boolean') {
+        return valor ? 1 : 0;
+    }
+
+    const texto = String(valor).trim();
+
+    const data = DATA_BR.exec(texto);
+    if (data) {
+        const [, dia, mes, ano, hora = '00', minuto = '00'] = data;
+        return new Date(
+            Number(ano),
+            Number(mes) - 1,
+            Number(dia),
+            Number(hora),
+            Number(minuto)
+        ).getTime();
+    }
+
+    const numerico = texto.replace('%', '').replace(',', '.').trim();
+    if (numerico !== '' && !Number.isNaN(Number(numerico))) {
+        return Number(numerico);
+    }
+
+    return texto.toLocaleLowerCase('pt-BR');
+}
+
+export function TabelaDetalhamento({
+    titulo = 'Detalhamento',
+    colunas,
+    linhas,
+    itemsPerPage = 10,
+}: Props) {
+    const [pagina, setPagina] = useState(1);
+    const [porPagina, setPorPagina] = useState(itemsPerPage);
+    const [ordenacao, setOrdenacao] = useState<Ordenacao | undefined>();
+
+    // Filtros novos podem encurtar a lista; volta para a primeira pagina.
+    useEffect(() => {
+        setPagina(1);
+    }, [linhas, porPagina, ordenacao]);
+
+    const linhasOrdenadas = useMemo(() => {
+        if (!ordenacao) {
+            return linhas;
+        }
+
+        const fator = ordenacao.direcao === 'asc' ? 1 : -1;
+
+        return [...linhas].sort((a, b) => {
+            const valorA = valorOrdenavel(a[ordenacao.chave]);
+            const valorB = valorOrdenavel(b[ordenacao.chave]);
+
+            if (typeof valorA === 'number' && typeof valorB === 'number') {
+                return (valorA - valorB) * fator;
+            }
+
+            return String(valorA).localeCompare(String(valorB), 'pt-BR') * fator;
+        });
+    }, [linhas, ordenacao]);
+
+    const inicio = (pagina - 1) * porPagina;
+    const linhasPagina = linhasOrdenadas.slice(inicio, inicio + porPagina);
+
+    const alternarOrdenacao = (chave: string) => {
+        setOrdenacao((atual) => {
+            if (atual?.chave !== chave) {
+                return { chave, direcao: 'asc' };
+            }
+
+            // Terceiro clique remove a ordenacao e volta a ordem original.
+            return atual.direcao === 'asc' ? { chave, direcao: 'desc' } : undefined;
+        });
+    };
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between gap-4 space-y-0">
+                <CardTitle className="text-base">{titulo}</CardTitle>
+                <div className="flex items-center gap-2">
+                    <Label htmlFor="registros-por-pagina" className="text-muted-foreground text-sm">
+                        Por página
+                    </Label>
+                    <Select
+                        value={String(porPagina)}
+                        onValueChange={(valor) => setPorPagina(Number(valor))}
+                    >
+                        <SelectTrigger id="registros-por-pagina" className="h-8 w-[80px]">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {OPCOES_POR_PAGINA.map((opcao) => (
+                                <SelectItem key={opcao} value={String(opcao)}>
+                                    {opcao}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </CardHeader>
+            <CardContent>
+                <div className="rounded-md border">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                {colunas.map((coluna) => {
+                                    const ativa = ordenacao?.chave === coluna.chave;
+                                    const Icone = !ativa
+                                        ? ChevronsUpDown
+                                        : ordenacao.direcao === 'asc'
+                                          ? ArrowUp
+                                          : ArrowDown;
+
+                                    return (
+                                        <TableHead key={coluna.chave} className="p-0">
+                                            <button
+                                                type="button"
+                                                onClick={() => alternarOrdenacao(coluna.chave)}
+                                                aria-label={`Ordenar por ${coluna.rotulo}`}
+                                                className="hover:text-foreground flex w-full items-center gap-1 px-4 py-3 text-left font-medium"
+                                            >
+                                                {coluna.rotulo}
+                                                <Icone
+                                                    className={cn(
+                                                        'h-3.5 w-3.5 shrink-0',
+                                                        ativa ? 'opacity-100' : 'opacity-40'
+                                                    )}
+                                                />
+                                            </button>
+                                        </TableHead>
+                                    );
+                                })}
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {linhasPagina.map((linha, index) => (
+                                <TableRow key={inicio + index}>
+                                    {colunas.map((coluna) => (
+                                        <TableCell key={coluna.chave}>
+                                            {String(linha[coluna.chave] ?? '')}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </div>
+                <Paginacao
+                    totalItems={linhasOrdenadas.length}
+                    itemsPerPage={porPagina}
+                    currentPage={pagina}
+                    onPageChange={setPagina}
+                />
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/presentation/organisms/app-sidebar.tsx
+++ b/resources/js/presentation/organisms/app-sidebar.tsx
@@ -2,7 +2,7 @@ import { NavMain } from '@/presentation/molecules/nav-main';
 import { NavUser } from '@/presentation/molecules/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { Link, usePage } from '@inertiajs/react';
-import { hasPermission } from '@/lib/auth';
+import { hasPermission, hasRole } from '@/lib/auth';
 import AppLogo from '@/presentation/atoms/app-logo';
 import type { User } from '@/types';
 import {
@@ -14,10 +14,11 @@ import {
     PERMISSION_SECAO_GESTAO_MODULOS,
     PERMISSION_SECAO_GESTAO_SETORES,
     PERMISSION_SECAO_GESTAO_ROLES,
+    PERMISSION_SECAO_RELATORIOS,
 } from '@/constants/permissions';
 
 /* Ícones ---------------------------------------------------------------- */
-import { BookOpen, Briefcase, Building, Calendar, Eye, Grid3X3, LayoutGrid, MapPin, School, ShieldCheck, Users } from 'lucide-react';
+import { BookOpen, Briefcase, Building, Calendar, Eye, FileBarChart2, Grid3X3, LayoutGrid, MapPin, School, ShieldCheck, Users } from 'lucide-react';
 
 /* ------------- Tipo local de item de menu (não exportado) ------------- */
 import type { LucideIcon } from 'lucide-react';
@@ -51,6 +52,7 @@ export function AppSidebar() {
               ...(hasPermission(user, PERMISSION_SECAO_GESTAO_UNIDADES)     ? [{ title: 'Gerenciar Unidades',       href: '/institucional/unidades',     icon: MapPin     }] : []),
               ...(hasPermission(user, PERMISSION_SECAO_GESTAO_MODULOS)      ? [{ title: 'Gerenciar Modulos',        href: '/institucional/modulos',      icon: Grid3X3    }] : []),
               ...(hasPermission(user, PERMISSION_SECAO_GESTAO_SETORES)      ? [{ title: 'Gerenciar Setores',        href: '/institucional/setors',       icon: Briefcase  }] : []),
+              ...(hasPermission(user, PERMISSION_SECAO_RELATORIOS)          ? [{ title: 'Relatórios',               href: hasRole(user, 'institucional') ? '/institucional/relatorios' : '/gestor/relatorios', icon: FileBarChart2 }] : []),
           ]
         : [];
 

--- a/resources/js/presentation/pages/Administrativo/Relatorios/RelatoriosInstitucionalPage.tsx
+++ b/resources/js/presentation/pages/Administrativo/Relatorios/RelatoriosInstitucionalPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import AppLayout from '@/presentation/templates/app-layout';
+import GenericHeader from '@/presentation/molecules/generic-header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { FiltrosReservasPeriodo } from '@/presentation/molecules/FiltrosReservasPeriodo';
+import { FiltrosOcupacaoEspacos } from '@/presentation/molecules/FiltrosOcupacaoEspacos';
+import { FiltrosInventarioEspacos } from '@/presentation/molecules/FiltrosInventarioEspacos';
+import { FiltrosIndicadoresConsolidados } from '@/presentation/molecules/FiltrosIndicadoresConsolidados';
+import { useGerarRelatorio } from '@/hooks/use-gerar-relatorio';
+import { FormatoRelatorio, FiltrosRelatorio, TipoRelatorio, TipoRelatorioOption } from '@/types';
+
+interface Props {
+    tipos_disponiveis: TipoRelatorioOption[];
+}
+
+export default function RelatoriosInstitucionalPage({ tipos_disponiveis }: Props) {
+    const [tipoSelecionado, setTipoSelecionado] = useState<TipoRelatorio | undefined>();
+    const [formatoSelecionado, setFormatoSelecionado] = useState<FormatoRelatorio>('pdf');
+    const [filtros, setFiltros] = useState<Partial<FiltrosRelatorio>>({});
+
+    const { gerar, estaGerando } = useGerarRelatorio('/institucional/relatorios/gerar');
+
+    const handleGerar = async () => {
+        if (!tipoSelecionado) return;
+
+        await gerar({
+            tipo: tipoSelecionado,
+            formato: formatoSelecionado,
+            filtros,
+        });
+    };
+
+    return (
+        <AppLayout breadcrumbs={[{ title: 'Relatórios', href: '/institucional/relatorios' }]}>
+            <GenericHeader
+                titulo="Relatórios — Gestão Institucional"
+                descricao="Gere relatórios consolidados das operações institucionais."
+            />
+
+            <Card className="mt-6">
+                <CardHeader>
+                    <CardTitle>Configurar Relatório</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                    <div>
+                        <Label htmlFor="tipo" className="mb-2 block">
+                            Tipo de Relatório
+                        </Label>
+                        <Select value={tipoSelecionado} onValueChange={(value) => setTipoSelecionado(value as TipoRelatorio)}>
+                            <SelectTrigger id="tipo">
+                                <SelectValue placeholder="Selecione um tipo" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {tipos_disponiveis.map((tipo) => (
+                                    <SelectItem key={tipo.value} value={tipo.value}>
+                                        {tipo.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {tipoSelecionado && (
+                        <div>
+                            <Label className="mb-4 block">Filtros</Label>
+                            {tipoSelecionado === 'reservas_periodo' && (
+                                <FiltrosReservasPeriodo filtros={filtros} onChange={setFiltros} />
+                            )}
+                            {tipoSelecionado === 'ocupacao_espacos' && (
+                                <FiltrosOcupacaoEspacos filtros={filtros} onChange={setFiltros} />
+                            )}
+                            {tipoSelecionado === 'inventario_espacos' && (
+                                <FiltrosInventarioEspacos filtros={filtros} onChange={setFiltros} />
+                            )}
+                            {tipoSelecionado === 'indicadores_consolidados' && (
+                                <FiltrosIndicadoresConsolidados filtros={filtros} onChange={setFiltros} />
+                            )}
+                        </div>
+                    )}
+
+                    <div>
+                        <Label htmlFor="formato" className="mb-2 block">
+                            Formato
+                        </Label>
+                        <Select value={formatoSelecionado} onValueChange={(value) => setFormatoSelecionado(value as FormatoRelatorio)}>
+                            <SelectTrigger id="formato">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="pdf">PDF</SelectItem>
+                                <SelectItem value="csv">CSV</SelectItem>
+                                <SelectItem value="xlsx">XLSX</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <Button
+                        onClick={handleGerar}
+                        disabled={!tipoSelecionado || estaGerando}
+                        className="w-full"
+                    >
+                        {estaGerando ? 'Gerando...' : 'Gerar Relatório'}
+                    </Button>
+                </CardContent>
+            </Card>
+        </AppLayout>
+    );
+}

--- a/resources/js/presentation/pages/Administrativo/Relatorios/RelatoriosInstitucionalPage.tsx
+++ b/resources/js/presentation/pages/Administrativo/Relatorios/RelatoriosInstitucionalPage.tsx
@@ -1,111 +1,173 @@
-import { useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import AppLayout from '@/presentation/templates/app-layout';
-import GenericHeader from '@/presentation/molecules/generic-header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
 import { FiltrosReservasPeriodo } from '@/presentation/molecules/FiltrosReservasPeriodo';
 import { FiltrosOcupacaoEspacos } from '@/presentation/molecules/FiltrosOcupacaoEspacos';
 import { FiltrosInventarioEspacos } from '@/presentation/molecules/FiltrosInventarioEspacos';
 import { FiltrosIndicadoresConsolidados } from '@/presentation/molecules/FiltrosIndicadoresConsolidados';
+import { ExportarRelatorio } from '@/presentation/molecules/ExportarRelatorio';
 import { useGerarRelatorio } from '@/hooks/use-gerar-relatorio';
-import { FormatoRelatorio, FiltrosRelatorio, TipoRelatorio, TipoRelatorioOption } from '@/types';
+import { useDadosRelatorio } from '@/hooks/use-dados-relatorio';
+import {
+    FormatoRelatorio,
+    FiltrosRelatorio,
+    OpcoesInventario,
+    TipoRelatorio,
+    TipoRelatorioOption,
+} from '@/types';
+import { BarChart3 } from 'lucide-react';
+
+const GraficoReservasPeriodo = lazy(() => import('@/presentation/molecules/GraficoReservasPeriodo'));
+const GraficoOcupacaoEspacos = lazy(() => import('@/presentation/molecules/GraficoOcupacaoEspacos'));
+const GraficoInventarioEspacos = lazy(() => import('@/presentation/molecules/GraficoInventarioEspacos'));
+const GraficoIndicadoresConsolidados = lazy(
+    () => import('@/presentation/molecules/GraficoIndicadoresConsolidados')
+);
 
 interface Props {
     tipos_disponiveis: TipoRelatorioOption[];
+    opcoes_inventario: OpcoesInventario;
 }
 
-export default function RelatoriosInstitucionalPage({ tipos_disponiveis }: Props) {
+export default function RelatoriosInstitucionalPage({
+    tipos_disponiveis,
+    opcoes_inventario,
+}: Props) {
     const [tipoSelecionado, setTipoSelecionado] = useState<TipoRelatorio | undefined>();
-    const [formatoSelecionado, setFormatoSelecionado] = useState<FormatoRelatorio>('pdf');
     const [filtros, setFiltros] = useState<Partial<FiltrosRelatorio>>({});
 
     const { gerar, estaGerando } = useGerarRelatorio('/institucional/relatorios/gerar');
+    const { dados, status, erro } = useDadosRelatorio(
+        '/institucional/relatorios/dados',
+        tipoSelecionado,
+        filtros
+    );
 
-    const handleGerar = async () => {
+    const handleExport = (formato: FormatoRelatorio) => {
         if (!tipoSelecionado) return;
-
-        await gerar({
-            tipo: tipoSelecionado,
-            formato: formatoSelecionado,
-            filtros,
-        });
+        void gerar({ tipo: tipoSelecionado, formato, filtros });
     };
 
     return (
         <AppLayout breadcrumbs={[{ title: 'Relatórios', href: '/institucional/relatorios' }]}>
-            <GenericHeader
-                titulo="Relatórios — Gestão Institucional"
-                descricao="Gere relatórios consolidados das operações institucionais."
-            />
-
-            <Card className="mt-6">
-                <CardHeader>
-                    <CardTitle>Configurar Relatório</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                    <div>
-                        <Label htmlFor="tipo" className="mb-2 block">
-                            Tipo de Relatório
-                        </Label>
-                        <Select value={tipoSelecionado} onValueChange={(value) => setTipoSelecionado(value as TipoRelatorio)}>
-                            <SelectTrigger id="tipo">
-                                <SelectValue placeholder="Selecione um tipo" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {tipos_disponiveis.map((tipo) => (
-                                    <SelectItem key={tipo.value} value={tipo.value}>
-                                        {tipo.label}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <div className="container mx-auto space-y-6 py-6">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                            <h1 className="text-2xl font-bold tracking-tight">
+                                Relatórios — Gestão Institucional
+                            </h1>
+                            <p className="text-muted-foreground">
+                                Explore os indicadores na tela e exporte quando precisar.
+                            </p>
+                        </div>
+                        <ExportarRelatorio
+                            onExport={handleExport}
+                            estaGerando={estaGerando}
+                            disabled={!tipoSelecionado}
+                        />
                     </div>
 
-                    {tipoSelecionado && (
-                        <div>
-                            <Label className="mb-4 block">Filtros</Label>
-                            {tipoSelecionado === 'reservas_periodo' && (
-                                <FiltrosReservasPeriodo filtros={filtros} onChange={setFiltros} />
-                            )}
-                            {tipoSelecionado === 'ocupacao_espacos' && (
-                                <FiltrosOcupacaoEspacos filtros={filtros} onChange={setFiltros} />
-                            )}
-                            {tipoSelecionado === 'inventario_espacos' && (
-                                <FiltrosInventarioEspacos filtros={filtros} onChange={setFiltros} />
-                            )}
-                            {tipoSelecionado === 'indicadores_consolidados' && (
-                                <FiltrosIndicadoresConsolidados filtros={filtros} onChange={setFiltros} />
-                            )}
-                        </div>
+                    <Tabs
+                        value={tipoSelecionado}
+                        onValueChange={(value) => setTipoSelecionado(value as TipoRelatorio)}
+                    >
+                        <TabsList className="flex h-auto flex-wrap justify-start gap-1">
+                            {tipos_disponiveis.map((tipo) => (
+                                <TabsTrigger key={tipo.value} value={tipo.value}>
+                                    {tipo.label}
+                                </TabsTrigger>
+                            ))}
+                        </TabsList>
+                    </Tabs>
+
+                    {!tipoSelecionado && (
+                        <Card className="border-dashed">
+                            <CardContent className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+                                <BarChart3 className="text-muted-foreground h-8 w-8" />
+                                <p className="text-muted-foreground text-sm">
+                                    Selecione um tipo de relatório para visualizar os dados.
+                                </p>
+                            </CardContent>
+                        </Card>
                     )}
 
-                    <div>
-                        <Label htmlFor="formato" className="mb-2 block">
-                            Formato
-                        </Label>
-                        <Select value={formatoSelecionado} onValueChange={(value) => setFormatoSelecionado(value as FormatoRelatorio)}>
-                            <SelectTrigger id="formato">
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="pdf">PDF</SelectItem>
-                                <SelectItem value="csv">CSV</SelectItem>
-                                <SelectItem value="xlsx">XLSX</SelectItem>
-                            </SelectContent>
-                        </Select>
-                    </div>
+                    {tipoSelecionado && (
+                        <>
+                            <Card>
+                                <CardHeader className="pb-3">
+                                    <CardTitle className="text-base">Filtros</CardTitle>
+                                </CardHeader>
+                                <CardContent>
+                                    {tipoSelecionado === 'reservas_periodo' && (
+                                        <FiltrosReservasPeriodo filtros={filtros} onChange={setFiltros} />
+                                    )}
+                                    {tipoSelecionado === 'ocupacao_espacos' && (
+                                        <FiltrosOcupacaoEspacos filtros={filtros} onChange={setFiltros} />
+                                    )}
+                                    {tipoSelecionado === 'inventario_espacos' && (
+                                        <FiltrosInventarioEspacos
+                                            filtros={filtros}
+                                            opcoes={opcoes_inventario}
+                                            onChange={setFiltros}
+                                        />
+                                    )}
+                                    {tipoSelecionado === 'indicadores_consolidados' && (
+                                        <FiltrosIndicadoresConsolidados filtros={filtros} onChange={setFiltros} />
+                                    )}
+                                </CardContent>
+                            </Card>
 
-                    <Button
-                        onClick={handleGerar}
-                        disabled={!tipoSelecionado || estaGerando}
-                        className="w-full"
-                    >
-                        {estaGerando ? 'Gerando...' : 'Gerar Relatório'}
-                    </Button>
-                </CardContent>
-            </Card>
+                            <div className="space-y-4">
+                                {status === 'loading' && (
+                                    <div className="space-y-4">
+                                        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                                            {Array.from({ length: 4 }).map((_, index) => (
+                                                <Skeleton key={index} className="h-28 w-full" />
+                                            ))}
+                                        </div>
+                                        <Skeleton className="h-[320px] w-full" />
+                                    </div>
+                                )}
+
+                                {status === 'error' && (
+                                    <Alert variant="destructive">
+                                        <AlertDescription>{erro}</AlertDescription>
+                                    </Alert>
+                                )}
+
+                                {status === 'empty' && (
+                                    <Card className="border-dashed">
+                                        <CardContent className="text-muted-foreground py-16 text-center text-sm">
+                                            Nenhum dado para os filtros selecionados.
+                                        </CardContent>
+                                    </Card>
+                                )}
+
+                                {status === 'success' && dados && (
+                                    <Suspense fallback={<Skeleton className="h-[320px] w-full" />}>
+                                        {tipoSelecionado === 'reservas_periodo' && (
+                                            <GraficoReservasPeriodo dados={dados} />
+                                        )}
+                                        {tipoSelecionado === 'ocupacao_espacos' && (
+                                            <GraficoOcupacaoEspacos dados={dados} />
+                                        )}
+                                        {tipoSelecionado === 'inventario_espacos' && (
+                                            <GraficoInventarioEspacos dados={dados} />
+                                        )}
+                                        {tipoSelecionado === 'indicadores_consolidados' && (
+                                            <GraficoIndicadoresConsolidados dados={dados} />
+                                        )}
+                                    </Suspense>
+                                )}
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
         </AppLayout>
     );
 }

--- a/resources/js/presentation/pages/Gestor/Relatorios/RelatoriosGestorPage.tsx
+++ b/resources/js/presentation/pages/Gestor/Relatorios/RelatoriosGestorPage.tsx
@@ -1,107 +1,161 @@
-import { useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import AppLayout from '@/presentation/templates/app-layout';
-import GenericHeader from '@/presentation/molecules/generic-header';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
 import { FiltrosReservasPeriodo } from '@/presentation/molecules/FiltrosReservasPeriodo';
 import { FiltrosOcupacaoEspacos } from '@/presentation/molecules/FiltrosOcupacaoEspacos';
 import { FiltrosInventarioEspacos } from '@/presentation/molecules/FiltrosInventarioEspacos';
+import { ExportarRelatorio } from '@/presentation/molecules/ExportarRelatorio';
 import { useGerarRelatorio } from '@/hooks/use-gerar-relatorio';
-import { FormatoRelatorio, FiltrosRelatorio, TipoRelatorio, TipoRelatorioOption } from '@/types';
+import { useDadosRelatorio } from '@/hooks/use-dados-relatorio';
+import {
+    FormatoRelatorio,
+    FiltrosRelatorio,
+    OpcoesInventario,
+    TipoRelatorio,
+    TipoRelatorioOption,
+} from '@/types';
+import { BarChart3 } from 'lucide-react';
+
+const GraficoReservasPeriodo = lazy(() => import('@/presentation/molecules/GraficoReservasPeriodo'));
+const GraficoOcupacaoEspacos = lazy(() => import('@/presentation/molecules/GraficoOcupacaoEspacos'));
+const GraficoInventarioEspacos = lazy(() => import('@/presentation/molecules/GraficoInventarioEspacos'));
 
 interface Props {
     tipos_disponiveis: TipoRelatorioOption[];
+    opcoes_inventario: OpcoesInventario;
 }
 
-export default function RelatoriosGestorPage({ tipos_disponiveis }: Props) {
+export default function RelatoriosGestorPage({
+    tipos_disponiveis,
+    opcoes_inventario,
+}: Props) {
     const [tipoSelecionado, setTipoSelecionado] = useState<TipoRelatorio | undefined>();
-    const [formatoSelecionado, setFormatoSelecionado] = useState<FormatoRelatorio>('pdf');
     const [filtros, setFiltros] = useState<Partial<FiltrosRelatorio>>({});
 
     const { gerar, estaGerando } = useGerarRelatorio('/gestor/relatorios/gerar');
+    const { dados, status, erro } = useDadosRelatorio(
+        '/gestor/relatorios/dados',
+        tipoSelecionado,
+        filtros
+    );
 
-    const handleGerar = async () => {
+    const handleExport = (formato: FormatoRelatorio) => {
         if (!tipoSelecionado) return;
-
-        await gerar({
-            tipo: tipoSelecionado,
-            formato: formatoSelecionado,
-            filtros,
-        });
+        void gerar({ tipo: tipoSelecionado, formato, filtros });
     };
 
     return (
         <AppLayout breadcrumbs={[{ title: 'Relatórios', href: '/gestor/relatorios' }]}>
-            <GenericHeader
-                titulo="Relatórios"
-                descricao="Gere relatórios operacionais dos espaços que você gerencia."
-            />
-
-            <Card className="mt-6">
-                <CardHeader>
-                    <CardTitle>Configurar Relatório</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                    <div>
-                        <Label htmlFor="tipo" className="mb-2 block">
-                            Tipo de Relatório
-                        </Label>
-                        <Select value={tipoSelecionado} onValueChange={(value) => setTipoSelecionado(value as TipoRelatorio)}>
-                            <SelectTrigger id="tipo">
-                                <SelectValue placeholder="Selecione um tipo" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {tipos_disponiveis.map((tipo) => (
-                                    <SelectItem key={tipo.value} value={tipo.value}>
-                                        {tipo.label}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
+            <div className="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+                <div className="container mx-auto space-y-6 py-6">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                            <h1 className="text-2xl font-bold tracking-tight">Relatórios</h1>
+                            <p className="text-muted-foreground">
+                                Acompanhe os espaços que você gerencia e exporte quando precisar.
+                            </p>
+                        </div>
+                        <ExportarRelatorio
+                            onExport={handleExport}
+                            estaGerando={estaGerando}
+                            disabled={!tipoSelecionado}
+                        />
                     </div>
 
-                    {tipoSelecionado && (
-                        <div>
-                            <Label className="mb-4 block">Filtros</Label>
-                            {tipoSelecionado === 'reservas_periodo' && (
-                                <FiltrosReservasPeriodo filtros={filtros} onChange={setFiltros} />
-                            )}
-                            {tipoSelecionado === 'ocupacao_espacos' && (
-                                <FiltrosOcupacaoEspacos filtros={filtros} onChange={setFiltros} />
-                            )}
-                            {tipoSelecionado === 'inventario_espacos' && (
-                                <FiltrosInventarioEspacos filtros={filtros} onChange={setFiltros} />
-                            )}
-                        </div>
+                    <Tabs
+                        value={tipoSelecionado}
+                        onValueChange={(value) => setTipoSelecionado(value as TipoRelatorio)}
+                    >
+                        <TabsList className="flex h-auto flex-wrap justify-start gap-1">
+                            {tipos_disponiveis.map((tipo) => (
+                                <TabsTrigger key={tipo.value} value={tipo.value}>
+                                    {tipo.label}
+                                </TabsTrigger>
+                            ))}
+                        </TabsList>
+                    </Tabs>
+
+                    {!tipoSelecionado && (
+                        <Card className="border-dashed">
+                            <CardContent className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+                                <BarChart3 className="text-muted-foreground h-8 w-8" />
+                                <p className="text-muted-foreground text-sm">
+                                    Selecione um tipo de relatório para visualizar os dados.
+                                </p>
+                            </CardContent>
+                        </Card>
                     )}
 
-                    <div>
-                        <Label htmlFor="formato" className="mb-2 block">
-                            Formato
-                        </Label>
-                        <Select value={formatoSelecionado} onValueChange={(value) => setFormatoSelecionado(value as FormatoRelatorio)}>
-                            <SelectTrigger id="formato">
-                                <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="pdf">PDF</SelectItem>
-                                <SelectItem value="csv">CSV</SelectItem>
-                                <SelectItem value="xlsx">XLSX</SelectItem>
-                            </SelectContent>
-                        </Select>
-                    </div>
+                    {tipoSelecionado && (
+                        <>
+                            <Card>
+                                <CardHeader className="pb-3">
+                                    <CardTitle className="text-base">Filtros</CardTitle>
+                                </CardHeader>
+                                <CardContent>
+                                    {tipoSelecionado === 'reservas_periodo' && (
+                                        <FiltrosReservasPeriodo filtros={filtros} onChange={setFiltros} />
+                                    )}
+                                    {tipoSelecionado === 'ocupacao_espacos' && (
+                                        <FiltrosOcupacaoEspacos filtros={filtros} onChange={setFiltros} />
+                                    )}
+                                    {tipoSelecionado === 'inventario_espacos' && (
+                                        <FiltrosInventarioEspacos
+                                            filtros={filtros}
+                                            opcoes={opcoes_inventario}
+                                            onChange={setFiltros}
+                                        />
+                                    )}
+                                </CardContent>
+                            </Card>
 
-                    <Button
-                        onClick={handleGerar}
-                        disabled={!tipoSelecionado || estaGerando}
-                        className="w-full"
-                    >
-                        {estaGerando ? 'Gerando...' : 'Gerar Relatório'}
-                    </Button>
-                </CardContent>
-            </Card>
+                            <div className="space-y-4">
+                                {status === 'loading' && (
+                                    <div className="space-y-4">
+                                        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                                            {Array.from({ length: 4 }).map((_, index) => (
+                                                <Skeleton key={index} className="h-28 w-full" />
+                                            ))}
+                                        </div>
+                                        <Skeleton className="h-[320px] w-full" />
+                                    </div>
+                                )}
+
+                                {status === 'error' && (
+                                    <Alert variant="destructive">
+                                        <AlertDescription>{erro}</AlertDescription>
+                                    </Alert>
+                                )}
+
+                                {status === 'empty' && (
+                                    <Card className="border-dashed">
+                                        <CardContent className="text-muted-foreground py-16 text-center text-sm">
+                                            Nenhum dado para os filtros selecionados.
+                                        </CardContent>
+                                    </Card>
+                                )}
+
+                                {status === 'success' && dados && (
+                                    <Suspense fallback={<Skeleton className="h-[320px] w-full" />}>
+                                        {tipoSelecionado === 'reservas_periodo' && (
+                                            <GraficoReservasPeriodo dados={dados} />
+                                        )}
+                                        {tipoSelecionado === 'ocupacao_espacos' && (
+                                            <GraficoOcupacaoEspacos dados={dados} />
+                                        )}
+                                        {tipoSelecionado === 'inventario_espacos' && (
+                                            <GraficoInventarioEspacos dados={dados} />
+                                        )}
+                                    </Suspense>
+                                )}
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
         </AppLayout>
     );
 }

--- a/resources/js/presentation/pages/Gestor/Relatorios/RelatoriosGestorPage.tsx
+++ b/resources/js/presentation/pages/Gestor/Relatorios/RelatoriosGestorPage.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import AppLayout from '@/presentation/templates/app-layout';
+import GenericHeader from '@/presentation/molecules/generic-header';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { FiltrosReservasPeriodo } from '@/presentation/molecules/FiltrosReservasPeriodo';
+import { FiltrosOcupacaoEspacos } from '@/presentation/molecules/FiltrosOcupacaoEspacos';
+import { FiltrosInventarioEspacos } from '@/presentation/molecules/FiltrosInventarioEspacos';
+import { useGerarRelatorio } from '@/hooks/use-gerar-relatorio';
+import { FormatoRelatorio, FiltrosRelatorio, TipoRelatorio, TipoRelatorioOption } from '@/types';
+
+interface Props {
+    tipos_disponiveis: TipoRelatorioOption[];
+}
+
+export default function RelatoriosGestorPage({ tipos_disponiveis }: Props) {
+    const [tipoSelecionado, setTipoSelecionado] = useState<TipoRelatorio | undefined>();
+    const [formatoSelecionado, setFormatoSelecionado] = useState<FormatoRelatorio>('pdf');
+    const [filtros, setFiltros] = useState<Partial<FiltrosRelatorio>>({});
+
+    const { gerar, estaGerando } = useGerarRelatorio('/gestor/relatorios/gerar');
+
+    const handleGerar = async () => {
+        if (!tipoSelecionado) return;
+
+        await gerar({
+            tipo: tipoSelecionado,
+            formato: formatoSelecionado,
+            filtros,
+        });
+    };
+
+    return (
+        <AppLayout breadcrumbs={[{ title: 'Relatórios', href: '/gestor/relatorios' }]}>
+            <GenericHeader
+                titulo="Relatórios"
+                descricao="Gere relatórios operacionais dos espaços que você gerencia."
+            />
+
+            <Card className="mt-6">
+                <CardHeader>
+                    <CardTitle>Configurar Relatório</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                    <div>
+                        <Label htmlFor="tipo" className="mb-2 block">
+                            Tipo de Relatório
+                        </Label>
+                        <Select value={tipoSelecionado} onValueChange={(value) => setTipoSelecionado(value as TipoRelatorio)}>
+                            <SelectTrigger id="tipo">
+                                <SelectValue placeholder="Selecione um tipo" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {tipos_disponiveis.map((tipo) => (
+                                    <SelectItem key={tipo.value} value={tipo.value}>
+                                        {tipo.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {tipoSelecionado && (
+                        <div>
+                            <Label className="mb-4 block">Filtros</Label>
+                            {tipoSelecionado === 'reservas_periodo' && (
+                                <FiltrosReservasPeriodo filtros={filtros} onChange={setFiltros} />
+                            )}
+                            {tipoSelecionado === 'ocupacao_espacos' && (
+                                <FiltrosOcupacaoEspacos filtros={filtros} onChange={setFiltros} />
+                            )}
+                            {tipoSelecionado === 'inventario_espacos' && (
+                                <FiltrosInventarioEspacos filtros={filtros} onChange={setFiltros} />
+                            )}
+                        </div>
+                    )}
+
+                    <div>
+                        <Label htmlFor="formato" className="mb-2 block">
+                            Formato
+                        </Label>
+                        <Select value={formatoSelecionado} onValueChange={(value) => setFormatoSelecionado(value as FormatoRelatorio)}>
+                            <SelectTrigger id="formato">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="pdf">PDF</SelectItem>
+                                <SelectItem value="csv">CSV</SelectItem>
+                                <SelectItem value="xlsx">XLSX</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <Button
+                        onClick={handleGerar}
+                        disabled={!tipoSelecionado || estaGerando}
+                        className="w-full"
+                    >
+                        {estaGerando ? 'Gerando...' : 'Gerar Relatório'}
+                    </Button>
+                </CardContent>
+            </Card>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -410,3 +410,29 @@ export interface TipoRelatorioOption {
     value: TipoRelatorio;
     label: string;
 }
+
+export interface OpcoesInventario {
+    unidades: Array<{ id: number; nome: string }>;
+    modulos: Array<{ id: number; nome: string; unidade_id: number }>;
+    andares: Array<{ id: number; nome: string; modulo_id: number }>;
+    espacos: Array<{ id: number; nome: string; andar_id: number }>;
+}
+
+export interface ColunaRelatorio {
+    chave: string;
+    rotulo: string;
+    tipo: string;
+    largura: number;
+}
+
+export interface DadosRelatorio {
+    tipo: TipoRelatorio;
+    titulo: string;
+    subtitulo: string;
+    colunas: ColunaRelatorio[];
+    linhas: Record<string, unknown>[];
+    sumario: Record<string, unknown>;
+    filtrosAplicados: Record<string, unknown>;
+    geradoPor: string;
+    geradoEm: string;
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -385,3 +385,28 @@ interface ReservaAvaliadaNotificationPayload {
     mensagem: string;
     url: string;
 }
+
+export type TipoRelatorio =
+    | 'reservas_periodo'
+    | 'ocupacao_espacos'
+    | 'inventario_espacos'
+    | 'indicadores_consolidados';
+
+export type FormatoRelatorio = 'pdf' | 'csv' | 'xlsx';
+
+export interface FiltrosRelatorio {
+    data_inicio?: string;
+    data_fim?: string;
+    situacoes?: SituacaoReserva[];
+    turnos?: Array<'manha' | 'tarde' | 'noite'>;
+    unidade_id?: number;
+    modulo_id?: number;
+    andar_id?: number;
+    espaco_id?: number;
+    setor_id?: number;
+}
+
+export interface TipoRelatorioOption {
+    value: TipoRelatorio;
+    label: string;
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>
@@ -35,7 +36,7 @@
 
         @routes
         @viteReactRefresh
-        @vite(['resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])
+        @vite(['resources/js/app.tsx', "resources/js/presentation/pages/{$page['component']}.tsx"])
         @inertiaHead
     </head>
     <body class="font-sans antialiased">

--- a/resources/views/relatorios/pdf/layout.blade.php
+++ b/resources/views/relatorios/pdf/layout.blade.php
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ $dados->titulo }}</title>
+    <style>
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            font-size: 11pt;
+            color: #1a1a1a;
+            margin: 0;
+            padding: 0;
+        }
+
+        header {
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid #1a1a1a;
+        }
+
+        .logo {
+            max-height: 60px;
+            margin-bottom: 10px;
+        }
+
+        .titulo {
+            font-size: 18pt;
+            font-weight: bold;
+            margin: 10px 0 5px 0;
+            color: #1a1a1a;
+        }
+
+        .subtitulo {
+            font-size: 12pt;
+            margin: 0 0 10px 0;
+            color: #555;
+        }
+
+        .metadata {
+            font-size: 9pt;
+            color: #888;
+            margin-top: 10px;
+        }
+
+        .conteudo {
+            margin: 20px 0;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 15px 0;
+        }
+
+        thead {
+            background-color: #f0f0f0;
+        }
+
+        th {
+            background-color: #f0f0f0;
+            border: 1px solid #ccc;
+            padding: 8px;
+            text-align: left;
+            font-weight: bold;
+            color: #1a1a1a;
+        }
+
+        td {
+            border: 1px solid #ddd;
+            padding: 8px;
+        }
+
+        tbody tr:nth-child(odd) {
+            background-color: #fafafa;
+        }
+
+        .filtros {
+            background-color: #f9f9f9;
+            border: 1px solid #ddd;
+            padding: 10px;
+            margin: 15px 0;
+            font-size: 10pt;
+        }
+
+        .filtros-titulo {
+            font-weight: bold;
+            margin-bottom: 8px;
+        }
+
+        .filtro-item {
+            margin: 5px 0;
+        }
+
+        .sumario {
+            background-color: #f0f0f0;
+            border: 1px solid #ddd;
+            padding: 10px;
+            margin: 15px 0;
+            font-size: 10pt;
+        }
+
+        .sumario-titulo {
+            font-weight: bold;
+            margin-bottom: 8px;
+        }
+
+        .sumario-item {
+            margin: 5px 0;
+        }
+
+        footer {
+            margin-top: 20px;
+            padding-top: 10px;
+            border-top: 1px solid #ddd;
+            font-size: 9pt;
+            color: #888;
+            text-align: right;
+        }
+
+        .page-number:before {
+            content: "Página " counter(page);
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="logo">
+            <img src="{{ public_path('logo.svg') }}" alt="Logo" style="max-height: 60px;">
+        </div>
+        <div class="titulo">{{ $dados->titulo }}</div>
+        @if ($dados->subtitulo)
+            <div class="subtitulo">{{ $dados->subtitulo }}</div>
+        @endif
+        <div class="metadata">
+            Gerado por {{ $dados->geradoPor }} em {{ $dados->geradoEm->setTimezone('America/Bahia')->format('d/m/Y H:i') }}
+        </div>
+    </header>
+
+    @yield('conteudo')
+
+    <footer>
+        <div class="page-number"></div>
+    </footer>
+
+    <script type="text/php">
+        if ( isset($pdf) ) {
+            $font = $pdf->get_font_family();
+            $size = $pdf->get_font_size();
+            $pdf->set_font($font, '', $size - 2);
+            $pdf->page_text(520, 810, "Página " . $pdf->get_page_number(), [], 10, [0, 0, 0]);
+        }
+    </script>
+</body>
+</html>

--- a/resources/views/relatorios/pdf/tabela.blade.php
+++ b/resources/views/relatorios/pdf/tabela.blade.php
@@ -1,0 +1,46 @@
+@extends('relatorios.pdf.layout')
+
+@section('conteudo')
+    <div class="conteudo">
+        @if (! empty($dados->filtrosAplicados))
+            <div class="filtros">
+                <div class="filtros-titulo">Filtros Aplicados:</div>
+                @foreach ($dados->filtrosAplicados as $chave => $valor)
+                    <div class="filtro-item">
+                        <strong>{{ $chave }}:</strong> {{ $valor }}
+                    </div>
+                @endforeach
+            </div>
+        @endif
+
+        <table>
+            <thead>
+                <tr>
+                    @foreach ($dados->colunas as $coluna)
+                        <th style="width: {{ $coluna->largura }}%;">{{ $coluna->rotulo }}</th>
+                    @endforeach
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($dados->linhas as $linha)
+                    <tr>
+                        @foreach ($dados->colunas as $coluna)
+                            <td>{{ $linha[$coluna->chave] ?? '—' }}</td>
+                        @endforeach
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+
+        @if (! empty($dados->sumario))
+            <div class="sumario">
+                <div class="sumario-titulo">Sumário:</div>
+                @foreach ($dados->sumario as $chave => $valor)
+                    <div class="sumario-item">
+                        <strong>{{ $chave }}:</strong> {{ $valor }}
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -119,11 +119,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::middleware(['permission:secao.relatorios'])->prefix('gestor')->name('gestor.')->group(function () {
         Route::get('relatorios', [GestorRelatorioController::class, 'index'])->name('relatorios.index');
         Route::post('relatorios/gerar', [GestorRelatorioController::class, 'gerar'])->name('relatorios.gerar');
+        Route::post('relatorios/dados', [GestorRelatorioController::class, 'dados'])->name('relatorios.dados');
     });
 
     Route::middleware(['permission:secao.relatorios'])->prefix('institucional')->name('institucional.')->group(function () {
         Route::get('relatorios', [InstitucionalRelatorioController::class, 'index'])->name('relatorios.index');
         Route::post('relatorios/gerar', [InstitucionalRelatorioController::class, 'gerar'])->name('relatorios.gerar');
+        Route::post('relatorios/dados', [InstitucionalRelatorioController::class, 'dados'])->name('relatorios.dados');
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\EspacoController;
+use App\Http\Controllers\Gestor\GestorRelatorioController;
 use App\Http\Controllers\Gestor\GestorReservaController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\Institucional\InstitucionalEspacoController;
 use App\Http\Controllers\Institucional\InstitucionalInstituicaoController;
 use App\Http\Controllers\Institucional\InstitucionalModuloController;
 use App\Http\Controllers\Institucional\InstitucionalPermissionController;
+use App\Http\Controllers\Institucional\InstitucionalRelatorioController;
 use App\Http\Controllers\Institucional\InstitucionalRoleController;
 use App\Http\Controllers\Institucional\InstitucionalSetorController;
 use App\Http\Controllers\Institucional\InstitucionalUnidadeController;
@@ -111,6 +113,17 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::resource('roles', InstitucionalRoleController::class)->only(['index', 'store', 'update', 'destroy']);
         Route::put('roles/{role}/permissions', [InstitucionalRoleController::class, 'syncPermissions'])->name('roles.syncpermissions');
         Route::get('permissions', [InstitucionalPermissionController::class, 'index'])->name('permissions.index');
+    });
+
+    // Gestão de Relatórios
+    Route::middleware(['permission:secao.relatorios'])->prefix('gestor')->name('gestor.')->group(function () {
+        Route::get('relatorios', [GestorRelatorioController::class, 'index'])->name('relatorios.index');
+        Route::post('relatorios/gerar', [GestorRelatorioController::class, 'gerar'])->name('relatorios.gerar');
+    });
+
+    Route::middleware(['permission:secao.relatorios'])->prefix('institucional')->name('institucional.')->group(function () {
+        Route::get('relatorios', [InstitucionalRelatorioController::class, 'index'])->name('relatorios.index');
+        Route::post('relatorios/gerar', [InstitucionalRelatorioController::class, 'gerar'])->name('relatorios.gerar');
     });
 });
 

--- a/stubs/export.model.stub
+++ b/stubs/export.model.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullModelClass;
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+class DummyClass implements FromCollection
+{
+    /**
+    * @return \Illuminate\Support\Collection
+    */
+    public function collection()
+    {
+        return DummyModelClass::all();
+    }
+}

--- a/stubs/export.plain.stub
+++ b/stubs/export.plain.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace DummyNamespace;
+
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+class DummyClass implements FromCollection
+{
+    /**
+    * @return \Illuminate\Support\Collection
+    */
+    public function collection()
+    {
+        //
+    }
+}

--- a/stubs/export.query-model.stub
+++ b/stubs/export.query-model.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullModelClass;
+use Maatwebsite\Excel\Concerns\FromQuery;
+
+class DummyClass implements FromQuery
+{
+    /**
+    * @return \Illuminate\Database\Query\Builder
+    */
+    public function query()
+    {
+        return DummyModelClass::query();
+    }
+}

--- a/stubs/export.query.stub
+++ b/stubs/export.query.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace DummyNamespace;
+
+use Maatwebsite\Excel\Concerns\FromQuery;
+
+class DummyClass implements FromQuery
+{
+    /**
+    * @return \Illuminate\Database\Query\Builder
+    */
+    public function query()
+    {
+        //
+    }
+}

--- a/stubs/import.collection.stub
+++ b/stubs/import.collection.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\ToCollection;
+
+class DummyClass implements ToCollection
+{
+    /**
+    * @param Collection $collection
+    */
+    public function collection(Collection $collection)
+    {
+        //
+    }
+}

--- a/stubs/import.model.stub
+++ b/stubs/import.model.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullModelClass;
+use Maatwebsite\Excel\Concerns\ToModel;
+
+class DummyClass implements ToModel
+{
+    /**
+    * @param array $row
+    *
+    * @return \Illuminate\Database\Eloquent\Model|null
+    */
+    public function model(array $row)
+    {
+        return new DummyModelClass([
+            //
+        ]);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__.'/../vendor/autoload.php';
+
+/*
+ * O container ja exporta as variaveis do .env para o ambiente do processo, e o
+ * <env force="true"> do PHPUnit atualiza apenas $_ENV e putenv() — nao $_SERVER.
+ * Como o repositorio de env do Laravel le $_SERVER primeiro, sem esta sincronia
+ * a suite ignora phpunit.xml e roda contra o banco de desenvolvimento, que o
+ * RefreshDatabase apaga a cada execucao.
+ */
+foreach ($_ENV as $chave => $valor) {
+    if (is_string($valor)) {
+        $_SERVER[$chave] = $valor;
+    }
+}


### PR DESCRIPTION
# feat(relatorios): add general reports module

**Base:** `develop` ← **Head:** `feat/general-reports`

## Resumo

Adiciona o módulo de relatórios para os perfis **gestor** e **institucional**: exploração dos indicadores na própria tela (KPIs, gráficos e tabela de detalhamento) e exportação sob demanda em **PDF / CSV / XLSX**. A branch está rebaseada sobre o `develop` atual (spatie/laravel-permission + frontend atômico), com a autorização integrada ao modelo de roles/permissions.

## O que entra

### Domínio

- **Strategy pattern:** `RelatorioService`, `RelatorioFactory`, exporters (PDF via dompdf, CSV/XLSX via maatwebsite/excel) e 4 relatórios — Reservas por Período, Ocupação de Espaços, Inventário de Espaços e Indicadores Consolidados.
- **Autorização:** cada tipo de relatório é gateado por permissão (`relatorios.*`); as rotas ficam sob `permission:secao.relatorios`. O escopo dos dados é aplicado por role no service (institucional: instituição inteira; gestor: apenas suas agendas).
- **Permissões:** `relatorios.*` + `secao.relatorios` adicionadas ao catálogo (migrations de seed + seeders Production), atribuídas a institucional (todas) e gestor (`reservas-periodo`, `ocupacao-espacos`, `inventario-espacos` + `secao.relatorios`).

### Dashboard na tela

- Endpoint `dados` por perfil retornando o relatório agregado em JSON, consumido pelo hook `use-dados-relatorio`.
- Gráficos em Recharts (`components/ui/chart` do shadcn): donut de situações, barras horizontais de ocupação e de capacidade, barras de distribuição.
- `TabelaDetalhamento` com **ordenação por coluna** (asc → desc → sem ordenação) e **registros por página** configurável (10/25/50/100). A ordenação reinterpreta o texto já formatado pelo backend, comparando datas `d/m/Y` cronologicamente e percentuais por valor numérico.
- Filtros do inventário por **combobox com busca por nome**, encadeados (unidade → módulo → andar → espaço); as opções vêm do backend já restritas ao escopo do usuário.
- Filtros de turno e situação combináveis entre si.

### Taxa de ocupação

A ocupação conta **slots distintos** (`data` + `horario_inicio` por espaço), não registros de `horarios`. A tabela tem múltiplas linhas para o mesmo slot de uma mesma reserva, e contar as repetições levava a taxas acima de 100% (uma sala marcava 339,8%). Com a contagem distinta o teto volta a fazer sentido — o máximo nos dados de produção passa a ser 87,8% — e 17 dos 20 espaços com dados no mês mantêm exatamente o mesmo valor. A coluna correspondente passou a se chamar "Slots".

### Ajustes de apresentação

- Abas usam `TipoRelatorioEnum::tituloCurto()` ("Reservas por Período" em vez de "Relatório de Reservas por Período"), já que o contexto está dado pela tela. O `titulo()` completo continua nos documentos exportados.
- Situações aparecem com rótulo legível ("Em Análise") em vez do valor cru (`em_analise`), na tela e nos exports, via `SituacaoReservaEnum::label()`.

### Infra

- Extensão `gd` habilitada nas imagens de desenvolvimento (necessária ao dompdf/phpspreadsheet).

## Correções fora do módulo (necessárias)

- **`resources/views/app.blade.php`:** o `@vite` apontava para `resources/js/pages/{component}.tsx`, caminho anterior ao refactor atômico (PR #227), que moveu as páginas para `presentation/pages/`. Isso quebrava o **build de produção em todas as páginas** (500, "Unable to locate file in Vite manifest"); em dev passava despercebido porque o modo hot não consulta o manifest.
- **`phpunit.xml` + `tests/bootstrap.php`:** a suíte rodava contra o **banco de desenvolvimento** e o `RefreshDatabase` o apagava a cada execução. O container já exporta `DB_*` no ambiente e o `<env>` do PHPUnit não sobrescrevia; mesmo com `force="true"`, o PHPUnit atualiza `$_ENV`/`putenv()` mas não `$_SERVER`, que é onde o Laravel lê primeiro. Agora a suíte usa `uniespacos_test`.

## Testes

Validado localmente: suíte PHP completa verde, Jest verde, PHPStan, Pint, `tsc` e ESLint limpos nos arquivos do módulo. Fluxos conferidos no navegador com restauração do dump de produção. **Os testes do módulo são mantidos localmente e não fazem parte deste PR.**

## Pós-merge / notas

- **Rebuild das imagens de dev** (`docker compose -f compose.dev.yml build workspace php-fpm`) — necessário para o `gd`.
- **Rodar migrations/seeders** para carregar as novas permissões.
- `gestor` também consegue abrir `/institucional/relatorios` (a `secao.relatorios` é compartilhada); o escopo dos dados permanece restrito às agendas dele, garantido no service.
- **Investigar fora deste PR — expansão dupla da recorrência.** `ProcessarCriacaoReserva:75-91` itera sobre cada horário solicitado e, para cada um, repete semanalmente (`addWeek`) até `data_final`. Quando o payload traz **uma** data por slot, isso é a recorrência funcionando. Quando traz **várias** ocorrências do mesmo slot (seleção de várias semanas no calendário), cada uma expande de novo até o fim e os intervalos se sobrepõem: a entrada da semana *k* gera as datas *k..N*, então a data *k* é inserida *k* vezes — daí a progressão 3, 6, 9, 12… observada em produção. Resultado: 37 reservas concentram 17.836 registros excedentes (79% das suas 22.632 linhas, 17% da tabela inteira). Zero duplicatas em 1.522 reservas de até 6 dias, onde o `while` não repete. `UpdateReservaJob:81-93` repete o mesmo padrão na edição.
- **Relacionado:** a expansão não consulta o campo `recorrencia` — 157 reservas marcadas como `unica` expandiram para várias datas.
