### PR TITLE
fix(ci): exclude prerelease tags and fix test database creation

### DIFF
--- a/.github/workflows/cicd-production.yml
+++ b/.github/workflows/cicd-production.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "!v*-*"
 
 permissions:
   contents: read
@@ -52,11 +53,12 @@ jobs:
         run: UID=${{ env.UID }} GID=${{ env.GID }} docker compose -f compose.test.yml up -d
       - name: Setup Environment
         run: |
+          docker compose -f compose.test.yml exec -T postgres psql -U uniespacos -d uniespacos -c "CREATE DATABASE uniespacos_test;"
           docker compose -f compose.test.yml exec -T workspace /bin/bash -c "
             cp .env.testing .env
             composer install --no-interaction --no-progress --prefer-dist
             php artisan key:generate
-            php artisan migrate --seed --force
+            DB_DATABASE=uniespacos_test php artisan migrate --seed --force
           "
       - name: Run Tests
         env:


### PR DESCRIPTION
## Summary
- Excludes `v*-*` prerelease tags from the production deploy trigger, so tags cut by the new staging release-please track (on `develop`) can never fire a production deploy.
- Creates and migrates the dedicated `uniespacos_test` database that `phpunit.xml` now requires (f9a86d0), which the CI ephemeral postgres container never provisioned — every backend test run was failing on `database "uniespacos_test" does not exist`.

## Test plan
- [ ] Confirm CI/CD - Production run passes lint + backend tests on this PR
- [ ] Push a real `v*` tag afterward and confirm it still deploys; push a `v*-rc.N` tag and confirm production does NOT fire