### PR TITLE
fix(ci): skip TelescopeServiceProvider when telescope package is absent

### DIFF
--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -7,9 +7,9 @@ use App\Providers\FortifyServiceProvider;
 use App\Providers\RelatorioServiceProvider;
 use App\Providers\TelescopeServiceProvider;
 
-return [
+return array_values(array_filter([
     AppServiceProvider::class,
     FortifyServiceProvider::class,
     RelatorioServiceProvider::class,
-    TelescopeServiceProvider::class,
-];
+    class_exists(\Laravel\Telescope\TelescopeApplicationServiceProvider::class) ? TelescopeServiceProvider::class : null,
+]));


### PR DESCRIPTION
## Summary
- Production Docker builds (`docker/production/php-fpm/Dockerfile`) run `composer install --no-dev`, so `laravel/telescope` (require-dev only) is never installed.
- `App\Providers\TelescopeServiceProvider` unconditionally `extends Laravel\Telescope\TelescopeApplicationServiceProvider`, so loading it fatals with `Class "Laravel\Telescope\TelescopeApplicationServiceProvider" not found` the moment the framework boots for `composer dump-autoload --optimize` (via the `post-autoload-dump` → `package:discover` script).
- This has crashed the "🐳 Build & Push to GHCR" job on every tagged release since Telescope was added — v1.3.0-rc, rc.1, rc.2, rc.3 all failed identically. Last known-good tagged build was v1.2.3 (before Telescope was added).
- Fix: only register `TelescopeServiceProvider` in `bootstrap/providers.php` when the Telescope package class actually exists.

## Test plan
- [x] Reproduced the crash locally by running `composer install --no-dev --no-scripts` then `composer dump-autoload --optimize` with no `.env` (mirrors the Dockerfile steps exactly).
- [x] Applied the fix and confirmed `composer dump-autoload --optimize` completes successfully (6056 classes generated, no errors).
- [ ] Confirm the next tagged release (`v1.3.0-rc.4`+) builds and pushes to GHCR successfully in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)