### PR TITLE
fix(style): use imported Telescope provider class per Pint fully_qualified_strict_types

### DIFF
--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -6,10 +6,11 @@ use App\Providers\AppServiceProvider;
 use App\Providers\FortifyServiceProvider;
 use App\Providers\RelatorioServiceProvider;
 use App\Providers\TelescopeServiceProvider;
+use Laravel\Telescope\TelescopeApplicationServiceProvider;
 
 return array_values(array_filter([
     AppServiceProvider::class,
     FortifyServiceProvider::class,
     RelatorioServiceProvider::class,
-    class_exists(\Laravel\Telescope\TelescopeApplicationServiceProvider::class) ? TelescopeServiceProvider::class : null,
+    class_exists(TelescopeApplicationServiceProvider::class) ? TelescopeServiceProvider::class : null,
 ]));


### PR DESCRIPTION
## Summary
- #237 fixed the GHCR production build crash by conditionally registering `TelescopeServiceProvider`, but used an inline leading-backslash FQCN (`\Laravel\Telescope\TelescopeApplicationServiceProvider::class`) inside `class_exists()`.
- That violates Pint's `fully_qualified_strict_types` rule, which failed the "🔍 Lint & Static Analysis" job on `v1.3.0-rc.4` and blocked the pipeline before it even reached the build/GHCR step.
- Fix: import the class via a `use` statement instead of referencing it inline.

## Test plan
- [x] `vendor/bin/pint --test` passes locally.
- [x] Re-verified the original crash fix still holds: `composer install --no-dev --no-scripts` + `composer dump-autoload --optimize` (no `.env`) completes successfully.
- [ ] Confirm next tag (`v1.3.0-rc.5`+) passes Lint and the GHCR build/push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)