### PR TITLE
fix(ci): use cloudflared-recognized env vars for Access service token auth

### DIFF
--- a/.github/workflows/cicd-production.yml
+++ b/.github/workflows/cicd-production.yml
@@ -172,8 +172,8 @@ jobs:
     environment:
       name: production
     env:
-      CF_ID: ${{ secrets.CF_ACCESS_CLIENT_ID_PRODUCTION }}
-      CF_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET_PRODUCTION }}
+      TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID_PRODUCTION }}
+      TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET_PRODUCTION }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/cicd-staging.yml
+++ b/.github/workflows/cicd-staging.yml
@@ -173,8 +173,8 @@ jobs:
     environment:
       name: staging
     env:
-      CF_ID: ${{ secrets.CF_ACCESS_CLIENT_ID_STAGING }}
-      CF_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET_STAGING }}
+      TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID_STAGING }}
+      TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET_STAGING }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The `deploy_staging` and `deploy_production` jobs authenticate to the deploy hosts through Cloudflare Access via `cloudflared access ssh` as an SSH `ProxyCommand`. They passed the service token credentials as `CF_ID`/`CF_SECRET` job-level env vars, but `cloudflared` only recognizes `TUNNEL_SERVICE_TOKEN_ID`/`TUNNEL_SERVICE_TOKEN_SECRET` for non-interactive auth.
- Without a recognized service token, `cloudflared` fell back to an interactive browser login, which cannot be completed on a headless GitHub Actions runner — the step hung for ~9 minutes and then failed with exit code 255. See the failing run: https://github.com/uniespacos/uniespacos/actions/runs/31897309265/job/95043488613
- Fix: rename the env vars in both `cicd-staging.yml` and `cicd-production.yml` to the names `cloudflared` actually reads. Same underlying secrets (`CF_ACCESS_CLIENT_ID_STAGING`/`_PRODUCTION`, `CF_ACCESS_CLIENT_SECRET_STAGING`/`_PRODUCTION`) are reused — no secret values changed.

## Test plan
- [ ] Merge into `develop`
- [ ] Let `release-please-staging` open/update its release PR, then approve and merge it to cut a new tag
- [ ] Confirm `cicd-staging.yml`'s `Deploy to Staging via SSH` step completes without the "A browser window should have opened" message and successfully deploys
- [ ] Apply the same verification path for production once promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)