### PR TITLE
fix(docker): correct default GHCR image path in compose.prod.yml

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,7 +1,7 @@
 services:
     web:
         container_name: web-production
-        image: ghcr.io/${GHCR_REPO_WEB:-uniespacos/app/web}:${IMAGE_TAG:-latest}
+        image: ghcr.io/${GHCR_REPO_WEB:-uniespacos/uniespacos/web}:${IMAGE_TAG:-latest}
         restart: unless-stopped
         env_file:
             - .env
@@ -22,7 +22,7 @@ services:
             - app
     app:
         container_name: app-production
-        image: ghcr.io/${GHCR_REPO_APP:-uniespacos/app/app}:${IMAGE_TAG:-latest}
+        image: ghcr.io/${GHCR_REPO_APP:-uniespacos/uniespacos/app}:${IMAGE_TAG:-latest}
         restart: unless-stopped
         volumes:
             - uniespacos-storage-production:/var/www/storage
@@ -35,7 +35,7 @@ services:
                 condition: service_healthy
     queue-worker:
         container_name: queue-worker-production
-        image: ghcr.io/${GHCR_REPO_APP:-uniespacos/app/app}:${IMAGE_TAG:-latest}
+        image: ghcr.io/${GHCR_REPO_APP:-uniespacos/uniespacos/app}:${IMAGE_TAG:-latest}
         restart: unless-stopped
         command: php artisan queue:work --verbose --tries=3 --timeout=90
         volumes:
@@ -49,7 +49,7 @@ services:
             - app
     reverb:
         container_name: reverb-production
-        image: ghcr.io/${GHCR_REPO_APP:-uniespacos/app/app}:${IMAGE_TAG:-latest}
+        image: ghcr.io/${GHCR_REPO_APP:-uniespacos/uniespacos/app}:${IMAGE_TAG:-latest}
         restart: unless-stopped
         command: php artisan reverb:start --host=0.0.0.0 --port=9000
         env_file:


### PR DESCRIPTION
## Summary
- After the Cloudflare Access fix (#241) got SSH working, the staging deploy failed at the image-pull step: `failed to resolve reference "ghcr.io/uniespacos/app/app:1.3.0-rc.6": not found`. See run: https://github.com/uniespacos/uniespacos/actions/runs/31908304636/job/95072849849
- CI (`cicd-staging.yml`/`cicd-production.yml`) pushes images to `ghcr.io/${{ github.repository }}/app` and `.../web`, which resolves to `ghcr.io/uniespacos/uniespacos/app` and `.../web` (repo is `uniespacos/uniespacos`) — confirmed in the build job logs.
- `compose.prod.yml`'s `GHCR_REPO_APP`/`GHCR_REPO_WEB` fallback defaults instead pointed at `uniespacos/app/app` and `uniespacos/app/web`, which don't exist. Since those env vars aren't set on the server, the wrong default was always used.
- Fix: correct the 4 default image references (web, app, queue-worker, reverb) in `compose.prod.yml` to `uniespacos/uniespacos/app`/`uniespacos/uniespacos/web`. This file is shared by both staging and production deploys.

## Test plan
- [ ] Merge into `develop`
- [ ] Let `release-please-staging` cut a new tag, or manually re-run the `Deploy to Staging` job
- [ ] Confirm the deploy script successfully pulls and starts `ghcr.io/uniespacos/uniespacos/app` and `.../web` images
- [ ] Apply the same verification path for production once promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)