### PR TITLE
fix(docker): give staging its own cert-free Caddy config

### DIFF
--- a/.github/workflows/cicd-staging.yml
+++ b/.github/workflows/cicd-staging.yml
@@ -206,16 +206,18 @@ jobs:
           scp ./compose.prod.yml ${{ secrets.SSH_USER_STAGING }}@${{ secrets.SSH_HOST_STAGING }}:${STAGING_PATH}/compose.prod.yml
           scp ./docker/production/scripts/deploy.sh ${{ secrets.SSH_USER_STAGING }}@${{ secrets.SSH_HOST_STAGING }}:${STAGING_PATH}/deploy.staging.sh
           scp ./docker/production/scripts/rollback.sh ${{ secrets.SSH_USER_STAGING }}@${{ secrets.SSH_HOST_STAGING }}:${STAGING_PATH}/rollback.staging.sh
+          scp ./docker/production/scripts/provision-staging.sh ${{ secrets.SSH_USER_STAGING }}@${{ secrets.SSH_HOST_STAGING }}:${STAGING_PATH}/provision-staging.sh
 
           ssh ${{ secrets.SSH_USER_STAGING }}@${{ secrets.SSH_HOST_STAGING }} "
             mkdir -p ${STAGING_PATH}/docker/production/caddy
             cat > ${STAGING_PATH}/docker/production/caddy/Caddyfile
-          " < ./docker/production/caddy/Caddyfile
+          " < ./docker/production/caddy/Caddyfile.staging
 
           ssh ${{ secrets.SSH_USER_STAGING }}@${{ secrets.SSH_HOST_STAGING }} "
             set -e
             cd ${STAGING_PATH}
-            chmod +x deploy.staging.sh rollback.staging.sh
+            chmod +x deploy.staging.sh rollback.staging.sh provision-staging.sh
+            ./provision-staging.sh ${STAGING_PATH}
             echo '${{ secrets.PAT_STAGING }}' | docker login ghcr.io -u '${{ github.actor }}' --password-stdin
             set -a
             source .env

--- a/docker/production/caddy/Caddyfile.staging
+++ b/docker/production/caddy/Caddyfile.staging
@@ -1,0 +1,19 @@
+# Global options
+{
+    auto_https off
+}
+
+:80 {
+    # Reverb WebSockets
+    @reverb {
+        path /app*
+    }
+    reverse_proxy @reverb reverb:9000 {
+        header_up Host {http.request.host}
+        header_up X-Forwarded-For {http.request.header.X-Forwarded-For}
+        header_up X-Forwarded-Proto {http.request.scheme}
+    }
+    root * /var/www/public
+    php_fastcgi app:9000
+    file_server
+}

--- a/docker/production/scripts/provision-staging.sh
+++ b/docker/production/scripts/provision-staging.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Idempotently provisions a staging-only Caddy folder so compose.prod.yml's
+# PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER can be satisfied without needing the
+# real production certs.
+
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: $0 <staging-path>"
+    exit 1
+fi
+
+STAGING_PATH="$1"
+CADDY_DIR="$STAGING_PATH/docker/production/caddy"
+
+mkdir -p "$CADDY_DIR/certs"
+touch "$CADDY_DIR/certs/uesb2025fullchain.pem" "$CADDY_DIR/certs/uesb2025privkey.pem"
+
+cd "$STAGING_PATH"
+touch .env
+if grep -q '^PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER=' .env; then
+    sed -i "s#^PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER=.*#PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER=$CADDY_DIR#" .env
+else
+    echo "PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER=$CADDY_DIR" >> .env
+fi


### PR DESCRIPTION
## Summary
- After the Cloudflare Access fix (#241) and GHCR image path fix (#243), staging deploys got as far as starting containers, then failed: `error mounting "/Caddyfile" to rootfs at "/etc/caddy/Caddyfile": ...not a directory`. Run: https://github.com/uniespacos/uniespacos/actions/runs/31910047222
- `compose.prod.yml` mounts the Caddyfile and TLS certs via `${PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER}`, which is production-only (real `uesb2025*.pem` certs, manually provisioned on the prod host). Staging has neither, so the variable resolves blank and Docker tries to bind-mount `/Caddyfile` (container-host root) onto the image's existing `/etc/caddy/Caddyfile` file.
- Per discussion, staging shouldn't need the production certs/path at all, and both environments must keep sharing the same `compose.prod.yml`. Considered a Compose override file (`-f compose.prod.yml -f compose.staging.yml`), but Compose merges `volumes` lists **by target path** — an override can't drop the cert-mount entries without the newer `!override`/`!reset` tags (Compose ≥ 2.24), which risks incompatibility with whatever Compose version runs on the staging host.
- Fix instead: staging self-provisions its own Caddy folder every deploy and points `PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER` at it (idempotent upsert into the staging host's own `.env`, only that one key touched):
  - New `docker/production/caddy/Caddyfile.staging` — HTTP-only (`auto_https off`, `:80` block), no `tls` directive, so the cert files are never actually read.
  - New `docker/production/scripts/provision-staging.sh` — creates `${STAGING_PATH}/docker/production/caddy/certs/` with empty placeholder `.pem` files (just so the bind mount has a real file to attach to) and upserts `PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER` in `.env`.
  - `cicd-staging.yml` scp's the new script, writes `Caddyfile.staging` (instead of the production Caddyfile) to the server, and runs `provision-staging.sh` before `deploy.staging.sh`.
- `compose.prod.yml`, `deploy.sh`, `rollback.sh`, and `cicd-production.yml` are all untouched — production's real cert setup keeps working exactly as before.

## Test plan
- [ ] Merge into `develop`
- [ ] Let `release-please-staging` cut a new tag (or manually re-run the `Deploy to Staging` job)
- [ ] Confirm `web-production`/`app-production` containers start successfully with no Caddyfile mount error
- [ ] Confirm the app is reachable over HTTP on the staging host

🤖 Generated with [Claude Code](https://claude.com/claude-code)