### PR TITLE
fix(docker): publish staging web port to match Cloudflare Tunnel target

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -6,7 +6,7 @@ services:
         env_file:
             - .env
         ports:
-            - "80:80"
+            - "${WEB_HTTP_PORT:-80}:80"
             - "443:443"
             - "443:443/udp"
         volumes:

--- a/docker/production/scripts/provision-staging.sh
+++ b/docker/production/scripts/provision-staging.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-# Idempotently provisions a staging-only Caddy folder so compose.prod.yml's
-# PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER can be satisfied without needing the
-# real production certs.
+# Idempotently provisions staging-only settings that compose.prod.yml
+# supports via env vars, without needing the real production certs or
+# port bindings:
+#   - PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER: points at a staging-only Caddy
+#     folder instead of the production certs directory.
+#   - WEB_HTTP_PORT: staging's Cloudflare Tunnel forwards to
+#     http://localhost:20211 on the host, so the web container's HTTP port
+#     must be published there instead of the production default (80).
 
 set -euo pipefail
 
@@ -12,14 +17,23 @@ fi
 
 STAGING_PATH="$1"
 CADDY_DIR="$STAGING_PATH/docker/production/caddy"
+STAGING_WEB_HTTP_PORT="20211"
 
 mkdir -p "$CADDY_DIR/certs"
 touch "$CADDY_DIR/certs/uesb2025fullchain.pem" "$CADDY_DIR/certs/uesb2025privkey.pem"
 
 cd "$STAGING_PATH"
 touch .env
-if grep -q '^PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER=' .env; then
-    sed -i "s#^PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER=.*#PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER=$CADDY_DIR#" .env
-else
-    echo "PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER=$CADDY_DIR" >> .env
-fi
+
+set_env_var() {
+    local key="$1"
+    local value="$2"
+    if grep -q "^${key}=" .env; then
+        sed -i "s#^${key}=.*#${key}=${value}#" .env
+    else
+        echo "${key}=${value}" >> .env
+    fi
+}
+
+set_env_var "PATH_TO_PRODUCTION_ENVIRONMENT_FOLDER" "$CADDY_DIR"
+set_env_var "WEB_HTTP_PORT" "$STAGING_WEB_HTTP_PORT"


### PR DESCRIPTION
## Summary
- Confirmed in the Cloudflare Zero Trust dashboard: the public hostname `uniespacos.phplemos.dev` is configured to forward to `http://localhost:20211` on the staging host.
- `compose.prod.yml`'s `web` service only ever published host port `80` (`"80:80"`), so even with the previous fixes (#241, #243, #245) getting the app running, tunnel traffic to `:20211` had nothing to connect to.
- Fix, staging-only, same pattern as #245 (parameterize with a default that keeps production's current behavior untouched):
  - `compose.prod.yml`: `"80:80"` → `"${WEB_HTTP_PORT:-80}:80"`. Production doesn't set `WEB_HTTP_PORT`, so it still binds `80:80` exactly as before.
  - `provision-staging.sh`: now also upserts `WEB_HTTP_PORT=20211` into the staging host's `.env` (refactored the existing single env-var upsert into a small `set_env_var` helper, reused for both keys).

## Test plan
- [ ] Merge into `develop`
- [ ] Let `release-please-staging` cut a new tag (or manually re-run the `Deploy to Staging` job)
- [ ] Confirm `docker compose ps` on staging shows the web container bound to `0.0.0.0:20211->80/tcp`
- [ ] Confirm `https://uniespacos.phplemos.dev` (via the tunnel) reaches the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)